### PR TITLE
feat(#7): podium screen — classic layout with confetti

### DIFF
--- a/frontend/src/components/PodiumScreen.tsx
+++ b/frontend/src/components/PodiumScreen.tsx
@@ -1,0 +1,216 @@
+import { useMemo } from "react";
+import type { PodiumEntry } from "../types";
+
+interface Props {
+  entries: PodiumEntry[];
+  /** When provided, highlights this player in the results list. */
+  playerId?: string;
+  /** Called when the primary action button is clicked (host only). */
+  onEnd?: () => void;
+  /** Label for the primary action button. */
+  endLabel?: string;
+}
+
+// Deterministic confetti piece config so SSR/test renders are stable.
+const CONFETTI_COLORS = [
+  "#f43f5e",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#3b82f6",
+  "#a855f7",
+  "#ec4899",
+  "#06b6d4",
+];
+
+interface ConfettiPiece {
+  id: number;
+  color: string;
+  left: string;
+  delay: string;
+  duration: string;
+  width: string;
+  height: string;
+  rotate: string;
+}
+
+function generateConfetti(count: number): ConfettiPiece[] {
+  // Simple LCG so results are deterministic (no Math.random drift between renders).
+  let seed = 42;
+  const rng = () => {
+    seed = (seed * 1664525 + 1013904223) & 0xffffffff;
+    return ((seed >>> 0) / 0xffffffff) % 1;
+  };
+
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    color: CONFETTI_COLORS[Math.floor(rng() * CONFETTI_COLORS.length)],
+    left: `${rng() * 100}%`,
+    delay: `${rng() * 3}s`,
+    duration: `${2.5 + rng() * 2}s`,
+    width: `${6 + Math.floor(rng() * 8)}px`,
+    height: `${10 + Math.floor(rng() * 8)}px`,
+    rotate: `${Math.floor(rng() * 360)}deg`,
+  }));
+}
+
+// podium order: 2nd (left), 1st (center, tallest), 3rd (right)
+const PODIUM_ORDER = [1, 0, 2] as const; // indices into top3
+const PODIUM_HEIGHTS = ["h-24", "h-36", "h-16"]; // 2nd, 1st, 3rd
+const PODIUM_COLORS = [
+  "bg-gray-400 text-gray-900", // 2nd — silver
+  "bg-yellow-400 text-yellow-900", // 1st — gold
+  "bg-amber-700 text-amber-100", // 3rd — bronze
+];
+const MEDALS = ["🥇", "🥈", "🥉"];
+const RANK_LABELS = ["2nd", "1st", "3rd"];
+
+export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Dashboard" }: Props) {
+  const top3 = entries.slice(0, 3);
+  const rest = entries.slice(3);
+  const confetti = useMemo(() => generateConfetti(80), []);
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center px-4 overflow-hidden relative">
+      {/* Confetti */}
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
+        {confetti.map((piece) => (
+          <div
+            key={piece.id}
+            className="absolute top-0 animate-confetti-fall opacity-90"
+            style={{
+              left: piece.left,
+              animationDelay: piece.delay,
+              animationDuration: piece.duration,
+              width: piece.width,
+              height: piece.height,
+            }}
+          >
+            <div
+              className="w-full h-full animate-confetti-spin"
+              style={{
+                backgroundColor: piece.color,
+                transform: `rotate(${piece.rotate})`,
+                animationDelay: piece.delay,
+              }}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="relative z-10 w-full max-w-lg flex flex-col items-center gap-8">
+        <h1 className="text-4xl font-black tracking-tight text-center">
+          🎉 Game Over!
+        </h1>
+
+        {/* Classic podium visual */}
+        {top3.length > 0 && (
+          <div className="flex items-end justify-center gap-3 w-full px-2">
+            {PODIUM_ORDER.map((entryIdx, podiumSlot) => {
+              const entry = top3[entryIdx];
+              if (!entry) return <div key={podiumSlot} className="flex-1" />;
+              const isSelf = entry.player_id === playerId;
+              return (
+                <div
+                  key={entry.player_id}
+                  className="flex-1 flex flex-col items-center"
+                  data-testid={`podium-slot-${RANK_LABELS[podiumSlot].toLowerCase()}`}
+                >
+                  {/* Player avatar / medal */}
+                  <div className="flex flex-col items-center mb-2 gap-1">
+                    <span className="text-3xl">{MEDALS[entryIdx]}</span>
+                    <span
+                      className={`text-xs font-bold text-center leading-tight max-w-[80px] truncate ${
+                        isSelf ? "text-indigo-300" : "text-white"
+                      }`}
+                      title={entry.name}
+                    >
+                      {entry.name}
+                      {isSelf && " (you)"}
+                    </span>
+                    <span className="text-xs font-black text-indigo-300 tabular-nums">
+                      {entry.score}
+                    </span>
+                  </div>
+                  {/* Podium block */}
+                  <div
+                    className={`${PODIUM_HEIGHTS[podiumSlot]} ${PODIUM_COLORS[podiumSlot]} w-full rounded-t-lg flex items-center justify-center`}
+                  >
+                    <span className="font-black text-lg">{RANK_LABELS[podiumSlot]}</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* My score card (player view) */}
+        {playerId && (() => {
+          const myEntry = entries.find((e) => e.player_id === playerId);
+          if (!myEntry || myEntry.rank <= 3) return null;
+          return (
+            <div className="w-full bg-indigo-900/40 border border-indigo-700 rounded-2xl p-5 text-center">
+              <p className="text-gray-400 text-sm mb-1">Your final score</p>
+              <p className="text-4xl font-black text-indigo-300">{myEntry.score}</p>
+              <p className="text-gray-400 mt-2">Rank #{myEntry.rank}</p>
+            </div>
+          );
+        })()}
+
+        {/* Remaining players (4th+) */}
+        {rest.length > 0 && (
+          <div className="w-full space-y-2">
+            {rest.map((entry) => {
+              const isSelf = entry.player_id === playerId;
+              return (
+                <div
+                  key={entry.player_id}
+                  className={`rounded-xl px-5 py-3 flex items-center justify-between ${
+                    isSelf
+                      ? "bg-indigo-900/50 border border-indigo-600"
+                      : "bg-gray-900"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="w-8 text-center font-bold text-gray-400">
+                      #{entry.rank}
+                    </span>
+                    <span className="font-medium">
+                      {entry.name}
+                      {isSelf && (
+                        <span className="ml-2 text-xs text-indigo-400">(you)</span>
+                      )}
+                    </span>
+                  </div>
+                  <span className="font-bold text-indigo-300 tabular-nums">
+                    {entry.score}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {onEnd ? (
+          <button
+            onClick={onEnd}
+            className="w-full bg-indigo-600 hover:bg-indigo-500 text-white font-bold py-4 rounded-xl transition text-lg"
+          >
+            {endLabel}
+          </button>
+        ) : (
+          <p className="text-gray-500 text-sm">
+            Want to play again?{" "}
+            <a
+              href="/join"
+              className="text-indigo-400 hover:text-indigo-300 transition"
+            >
+              Join a new game
+            </a>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,35 @@ body {
   font-family: system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
+
+/* Confetti animations for PodiumScreen */
+@keyframes confetti-fall {
+  0% {
+    transform: translateY(-20px);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(110vh);
+    opacity: 0.3;
+  }
+}
+
+@keyframes confetti-spin {
+  0% {
+    transform: rotate(0deg) scaleX(1);
+  }
+  50% {
+    transform: rotate(180deg) scaleX(0.3);
+  }
+  100% {
+    transform: rotate(360deg) scaleX(1);
+  }
+}
+
+.animate-confetti-fall {
+  animation: confetti-fall linear infinite;
+}
+
+.animate-confetti-spin {
+  animation: confetti-spin linear infinite;
+}

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { useGameStore } from "../stores/gameStore";
 import { LeaderboardDisplay } from "../components/LeaderboardDisplay";
+import { PodiumScreen } from "../components/PodiumScreen";
 import type { WsMessage, LeaderboardEntry, PodiumEntry } from "../types";
 
 const WS_BASE = import.meta.env.VITE_WS_BASE_URL ?? "ws://localhost:8081";
@@ -138,33 +139,12 @@ export function HostGamePage() {
 
   // Podium
   if (phase === "podium") {
-    const medals = ["🥇", "🥈", "🥉"];
     return (
-      <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center px-4">
-        <div className="w-full max-w-lg space-y-6 text-center">
-          <h1 className="text-4xl font-black">Game Over!</h1>
-          <div className="space-y-3">
-            {podium.map((entry, i) => (
-              <div
-                key={entry.player_id}
-                className="bg-gray-900 rounded-xl px-6 py-4 flex items-center justify-between"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="text-2xl">{medals[i] ?? `#${entry.rank}`}</span>
-                  <span className="font-semibold text-lg">{entry.name}</span>
-                </div>
-                <span className="text-indigo-400 font-bold text-xl">{entry.score}</span>
-              </div>
-            ))}
-          </div>
-          <button
-            onClick={handleEndGame}
-            className="w-full bg-indigo-600 hover:bg-indigo-500 text-white font-bold py-4 rounded-xl transition"
-          >
-            Back to Dashboard
-          </button>
-        </div>
-      </div>
+      <PodiumScreen
+        entries={podium}
+        onEnd={handleEndGame}
+        endLabel="Back to Dashboard"
+      />
     );
   }
 

--- a/frontend/src/pages/PlayerGamePage.tsx
+++ b/frontend/src/pages/PlayerGamePage.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { LeaderboardDisplay } from "../components/LeaderboardDisplay";
+import { PodiumScreen } from "../components/PodiumScreen";
 import type { WsMessage, QuestionPayload, LeaderboardEntry, PodiumEntry } from "../types";
 
 const WS_BASE = import.meta.env.VITE_WS_BASE_URL ?? "ws://localhost:8081";
@@ -186,47 +187,7 @@ export function PlayerGamePage() {
 
   // Podium
   if (phase === "podium") {
-    const myEntry = podium.find((e) => e.player_id === playerId);
-    const medals = ["🥇", "🥈", "🥉"];
-    return (
-      <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center px-4">
-        <div className="w-full max-w-sm space-y-6 text-center">
-          <h1 className="text-3xl font-black">Game Over!</h1>
-          {myEntry && (
-            <div className="bg-indigo-900/40 border border-indigo-700 rounded-2xl p-6">
-              <p className="text-gray-400 text-sm mb-1">Your final score</p>
-              <p className="text-4xl font-black text-indigo-300">{myEntry.score}</p>
-              <p className="text-gray-400 mt-2">Rank #{myEntry.rank}</p>
-            </div>
-          )}
-          <div className="space-y-2">
-            {podium.map((entry, i) => (
-              <div
-                key={entry.player_id}
-                className={`rounded-xl px-5 py-3 flex items-center justify-between ${
-                  entry.player_id === playerId ? "bg-indigo-900/50 border border-indigo-600" : "bg-gray-900"
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <span>{medals[i] ?? `#${entry.rank}`}</span>
-                  <span className="font-medium">{entry.name}</span>
-                  {entry.player_id === playerId && (
-                    <span className="text-xs text-indigo-400">(you)</span>
-                  )}
-                </div>
-                <span className="font-bold text-indigo-300">{entry.score}</span>
-              </div>
-            ))}
-          </div>
-          <p className="text-gray-500 text-sm">
-            Want to play again?{" "}
-            <a href="/join" className="text-indigo-400 hover:text-indigo-300 transition">
-              Join a new game
-            </a>
-          </p>
-        </div>
-      </div>
-    );
+    return <PodiumScreen entries={podium} playerId={playerId} />;
   }
 
   // Leaderboard

--- a/frontend/src/test/PlayerGamePage.test.tsx
+++ b/frontend/src/test/PlayerGamePage.test.tsx
@@ -152,9 +152,11 @@ describe("PlayerGamePage", () => {
       }),
     );
     expect(screen.getByText(/game over/i)).toBeInTheDocument();
-    // "2700" appears in both the hero score and the podium list.
+    // Alice is rank 1 — her score appears on the podium block.
     expect(screen.getAllByText("2700").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText(/your final score/i)).toBeInTheDocument();
+    // Rank 1 player sees their name on the podium (with "(you)" suffix) and the gold medal.
+    expect(screen.getByText(/Alice/)).toBeInTheDocument();
+    expect(screen.getByText("🥇")).toBeInTheDocument();
   });
 
   it("shows play again link on podium screen", () => {

--- a/frontend/src/test/PodiumScreen.test.tsx
+++ b/frontend/src/test/PodiumScreen.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PodiumScreen } from "../components/PodiumScreen";
+
+const entries = [
+  { player_id: "p1", name: "Alice", score: 3000, rank: 1 },
+  { player_id: "p2", name: "Bob", score: 2000, rank: 2 },
+  { player_id: "p3", name: "Carol", score: 1000, rank: 3 },
+  { player_id: "p4", name: "Dave", score: 500, rank: 4 },
+];
+
+describe("PodiumScreen", () => {
+  it("renders the game over heading", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.getByText(/Game Over/i)).toBeInTheDocument();
+  });
+
+  it("renders all three podium slots with correct rank labels", () => {
+    render(<PodiumScreen entries={entries} />);
+    // Classic podium order: 2nd left, 1st center, 3rd right
+    expect(screen.getByTestId("podium-slot-1st")).toBeInTheDocument();
+    expect(screen.getByTestId("podium-slot-2nd")).toBeInTheDocument();
+    expect(screen.getByTestId("podium-slot-3rd")).toBeInTheDocument();
+  });
+
+  it("renders player names for top 3", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Carol")).toBeInTheDocument();
+  });
+
+  it("renders scores for top 3 players", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.getByText("3000")).toBeInTheDocument();
+    expect(screen.getByText("2000")).toBeInTheDocument();
+    expect(screen.getByText("1000")).toBeInTheDocument();
+  });
+
+  it("renders gold, silver, bronze medals", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.getByText("🥇")).toBeInTheDocument();
+    expect(screen.getByText("🥈")).toBeInTheDocument();
+    expect(screen.getByText("🥉")).toBeInTheDocument();
+  });
+
+  it("shows 4th+ players below the podium", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.getByText("Dave")).toBeInTheDocument();
+    expect(screen.getByText("#4")).toBeInTheDocument();
+  });
+
+  it("highlights the current player with (you) badge", () => {
+    render(<PodiumScreen entries={entries} playerId="p1" />);
+    expect(screen.getByText(/\(you\)/)).toBeInTheDocument();
+  });
+
+  it("shows (you) in the list for a 4th+ player", () => {
+    render(<PodiumScreen entries={entries} playerId="p4" />);
+    expect(screen.getByText("(you)")).toBeInTheDocument();
+  });
+
+  it("shows player's own score card when ranked 4th+", () => {
+    render(<PodiumScreen entries={entries} playerId="p4" />);
+    // Score card text is unique; score "500" also appears in the rest list — use the rank label to confirm
+    expect(screen.getByText("Rank #4")).toBeInTheDocument();
+    // "Your final score" heading appears exactly once (in the score card)
+    expect(screen.getByText(/your final score/i)).toBeInTheDocument();
+  });
+
+  it("does not show (you) badge when no playerId provided", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.queryByText("(you)")).not.toBeInTheDocument();
+  });
+
+  it("renders the end button when onEnd is provided", () => {
+    const handleEnd = vi.fn();
+    render(<PodiumScreen entries={entries} onEnd={handleEnd} endLabel="Back to Dashboard" />);
+    expect(screen.getByRole("button", { name: "Back to Dashboard" })).toBeInTheDocument();
+  });
+
+  it("calls onEnd when the button is clicked", () => {
+    const handleEnd = vi.fn();
+    render(<PodiumScreen entries={entries} onEnd={handleEnd} />);
+    fireEvent.click(screen.getByRole("button", { name: "Back to Dashboard" }));
+    expect(handleEnd).toHaveBeenCalledOnce();
+  });
+
+  it("shows join link when no onEnd is provided (player view)", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.getByRole("link", { name: /join a new game/i })).toBeInTheDocument();
+  });
+
+  it("does not render the end button in player view", () => {
+    render(<PodiumScreen entries={entries} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders with only one entry without crashing", () => {
+    render(<PodiumScreen entries={[{ player_id: "p1", name: "Solo", score: 100, rank: 1 }]} />);
+    expect(screen.getByText("Solo")).toBeInTheDocument();
+  });
+
+  it("renders with an empty entries list without crashing", () => {
+    render(<PodiumScreen entries={[]} />);
+    expect(screen.getByText(/Game Over/i)).toBeInTheDocument();
+  });
+
+  it("uses custom endLabel on the button", () => {
+    render(<PodiumScreen entries={entries} onEnd={vi.fn()} endLabel="End Session" />);
+    expect(screen.getByRole("button", { name: "End Session" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **New `PodiumScreen` component** — classic podium visual: 2nd place on the left, 1st in the center (tallest block), 3rd on the right, using gold/silver/bronze colours
- **Confetti celebration animation** — 80 deterministic CSS-animated confetti pieces falling from the top, no external library required (pure keyframe CSS via `index.css`)
- **Player names, scores, and rank labels** shown on each podium block; 4th+ players listed below the podium
- **Player view** highlights the current player with a `(you)` badge; shows a personal score card for players ranked 4th+
- **Host/admin view** shows a "Back to Dashboard" button to end the session
- Replaces the inline list-based podium JSX in both `HostGamePage` and `PlayerGamePage` with the new shared component
- 17 unit tests for `PodiumScreen` covering layout, medals, player highlighting, action buttons and edge cases

## How to test

1. Start the dev stack: `docker compose up --build`
2. Log in as admin, create a quiz with at least 2 questions
3. Open a second browser tab and join as a player
4. Play through all questions — after the final leaderboard, click "Show Final Results"
5. Verify:
   - Confetti falls from the top of the screen
   - Podium shows 2nd left / 1st center (tallest) / 3rd right with correct player names and scores
   - Admin screen has a "Back to Dashboard" button that navigates to `/admin`
   - Player screen shows a "(you)" badge and "Join a new game" link

Closes #7