### PR TITLE
fix(#15): skip 401 redirect for auth endpoints

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,10 +14,16 @@ apiClient.interceptors.request.use((config) => {
   return config;
 });
 
+const AUTH_ENDPOINTS = ["/auth/login", "/auth/register"];
+
 apiClient.interceptors.response.use(
   (res) => res,
   (err) => {
-    if (err.response?.status === 401) {
+    const requestUrl = err.config?.url ?? "";
+    const isAuthEndpoint = AUTH_ENDPOINTS.some((ep) =>
+      requestUrl.startsWith(ep)
+    );
+    if (err.response?.status === 401 && !isAuthEndpoint) {
       useAuthStore.getState().clearAuth();
       window.location.href = "/login";
     }

--- a/frontend/src/test/apiClient.test.ts
+++ b/frontend/src/test/apiClient.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the auth store before importing apiClient
+const mockClearAuth = vi.fn();
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: {
+    getState: () => ({
+      token: null,
+      clearAuth: mockClearAuth,
+    }),
+  },
+}));
+
+// Capture window.location.href assignments
+let locationHref = "";
+Object.defineProperty(window, "location", {
+  value: {
+    get href() {
+      return locationHref;
+    },
+    set href(v: string) {
+      locationHref = v;
+    },
+  },
+  writable: true,
+});
+
+type InterceptorHandler = {
+  rejected: (err: unknown) => Promise<unknown>;
+} | null;
+
+function getInterceptor(apiClient: {
+  interceptors: { response: { handlers: InterceptorHandler[] } };
+}) {
+  const handler = apiClient.interceptors.response.handlers.find(
+    (h) => h !== null
+  );
+  if (!handler) throw new Error("No interceptor found");
+  return handler.rejected;
+}
+
+describe("apiClient 401 interceptor", () => {
+  beforeEach(() => {
+    mockClearAuth.mockClear();
+    locationHref = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("clears auth and redirects to /login on 401 from a non-auth endpoint", async () => {
+    const { apiClient } = await import("../api/client");
+    const rejected = getInterceptor(
+      apiClient as Parameters<typeof getInterceptor>[0]
+    );
+
+    const err = Object.assign(new Error("Unauthorized"), {
+      response: { status: 401 },
+      config: { url: "/quizzes" },
+    });
+
+    await rejected(err).catch(() => {});
+
+    expect(mockClearAuth).toHaveBeenCalledOnce();
+    expect(locationHref).toBe("/login");
+  });
+
+  it("does NOT redirect on 401 from /auth/login", async () => {
+    const { apiClient } = await import("../api/client");
+    const rejected = getInterceptor(
+      apiClient as Parameters<typeof getInterceptor>[0]
+    );
+
+    const err = Object.assign(new Error("Unauthorized"), {
+      response: { status: 401 },
+      config: { url: "/auth/login" },
+    });
+
+    await rejected(err).catch(() => {});
+
+    expect(mockClearAuth).not.toHaveBeenCalled();
+    expect(locationHref).toBe("");
+  });
+
+  it("does NOT redirect on 401 from /auth/register", async () => {
+    const { apiClient } = await import("../api/client");
+    const rejected = getInterceptor(
+      apiClient as Parameters<typeof getInterceptor>[0]
+    );
+
+    const err = Object.assign(new Error("Unauthorized"), {
+      response: { status: 401 },
+      config: { url: "/auth/register" },
+    });
+
+    await rejected(err).catch(() => {});
+
+    expect(mockClearAuth).not.toHaveBeenCalled();
+    expect(locationHref).toBe("");
+  });
+
+  it("still rejects the promise on 401 so callers can handle the error", async () => {
+    const { apiClient } = await import("../api/client");
+    const rejected = getInterceptor(
+      apiClient as Parameters<typeof getInterceptor>[0]
+    );
+
+    const err = Object.assign(new Error("Unauthorized"), {
+      response: { status: 401 },
+      config: { url: "/auth/login" },
+    });
+
+    await expect(rejected(err)).rejects.toThrow("Unauthorized");
+  });
+});


### PR DESCRIPTION
## Summary

- The 401 response interceptor in `frontend/src/api/client.ts` was unconditionally calling `clearAuth()` and redirecting to `/login` on any 401 response — including the one returned by `/auth/login` when credentials are wrong
- This navigation reset page state, wiping the error message before the user could read it
- Fix: added an `AUTH_ENDPOINTS` list (`/auth/login`, `/auth/register`); the interceptor now skips the redirect when the failing request targets one of those endpoints

## Changes

- `frontend/src/api/client.ts` — guard the 401 redirect with an `isAuthEndpoint` check
- `frontend/src/test/apiClient.test.ts` — 4 new tests covering: redirect on non-auth 401, no redirect on `/auth/login` 401, no redirect on `/auth/register` 401, promise still rejects so callers can handle the error

## How to test

1. Start the dev environment: `docker compose up --build`
2. Go to `http://localhost:5173/login`
3. Enter wrong credentials and click Sign in
4. Verify the "invalid credentials" error message stays visible

Closes #15