### PR TITLE
feat(#16): replace window.confirm with custom ConfirmModal

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,0 +1,38 @@
+interface ConfirmModalProps {
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({ title, message, onConfirm, onCancel }: ConfirmModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-title"
+    >
+      <div className="bg-gray-900 border border-gray-700 rounded-2xl p-6 w-full max-w-sm mx-4 shadow-2xl">
+        <h2 id="confirm-modal-title" className="text-lg font-bold text-white mb-2">
+          {title}
+        </h2>
+        <p className="text-sm text-gray-400 mb-6">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm font-semibold text-gray-300 bg-gray-700 hover:bg-gray-600 rounded-lg transition"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm font-semibold text-white bg-red-600 hover:bg-red-500 rounded-lg transition"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/QuizListPage.tsx
+++ b/frontend/src/pages/QuizListPage.tsx
@@ -1,11 +1,19 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { listQuizzes, deleteQuiz } from "../api/quizzes";
 import { createSession } from "../api/sessions";
+import { ConfirmModal } from "../components/ConfirmModal";
+
+interface PendingDelete {
+  id: string;
+  title: string;
+}
 
 export function QuizListPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
 
   const { data: quizzes = [], isLoading, isError } = useQuery({
     queryKey: ["quizzes"],
@@ -14,7 +22,10 @@ export function QuizListPage() {
 
   const deleteMutation = useMutation({
     mutationFn: deleteQuiz,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["quizzes"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["quizzes"] });
+      setPendingDelete(null);
+    },
   });
 
   const hostMutation = useMutation({
@@ -22,13 +33,30 @@ export function QuizListPage() {
     onSuccess: (data) => navigate(`/admin/host/${data.code}`),
   });
 
-  function handleDelete(id: string, title: string) {
-    if (!window.confirm(`Delete "${title}"? This cannot be undone.`)) return;
-    deleteMutation.mutate(id);
+  function handleDeleteClick(id: string, title: string) {
+    setPendingDelete({ id, title });
+  }
+
+  function handleConfirmDelete() {
+    if (pendingDelete) {
+      deleteMutation.mutate(pendingDelete.id);
+    }
+  }
+
+  function handleCancelDelete() {
+    setPendingDelete(null);
   }
 
   return (
     <div>
+      {pendingDelete && (
+        <ConfirmModal
+          title={`Delete "${pendingDelete.title}"?`}
+          message="This cannot be undone."
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDelete}
+        />
+      )}
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-2xl font-bold">Quizzes</h2>
         <Link
@@ -81,7 +109,7 @@ export function QuizListPage() {
                   Edit
                 </Link>
                 <button
-                  onClick={() => handleDelete(quiz.id, quiz.title)}
+                  onClick={() => handleDeleteClick(quiz.id, quiz.title)}
                   disabled={deleteMutation.isPending}
                   className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 transition"
                 >

--- a/frontend/src/test/ConfirmModal.test.tsx
+++ b/frontend/src/test/ConfirmModal.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ConfirmModal } from "../components/ConfirmModal";
+
+describe("ConfirmModal", () => {
+  it("renders title and message", () => {
+    render(
+      <ConfirmModal
+        title='Delete "My Quiz"?'
+        message="This cannot be undone."
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Delete "My Quiz"?')).toBeInTheDocument();
+    expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when Delete button is clicked", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmModal
+        title="Delete?"
+        message="Are you sure?"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when Cancel button is clicked", async () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmModal
+        title="Delete?"
+        message="Are you sure?"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("has accessible dialog role and aria-modal", () => {
+    render(
+      <ConfirmModal
+        title="Delete?"
+        message="Are you sure?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/QuizListPage.test.tsx
+++ b/frontend/src/test/QuizListPage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -43,5 +44,56 @@ describe("QuizListPage", () => {
     vi.mocked(quizzesApi.listQuizzes).mockRejectedValue(new Error("network error"));
     renderList();
     expect(await screen.findByText(/failed to load/i)).toBeInTheDocument();
+  });
+
+  it("opens confirm modal when Delete is clicked", async () => {
+    vi.mocked(quizzesApi.listQuizzes).mockResolvedValue([
+      { id: "1", admin_id: "a", title: "History Quiz", created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    renderList();
+    await screen.findByText("History Quiz");
+
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/delete "history quiz"/i)).toBeInTheDocument();
+    expect(screen.getByText(/this cannot be undone/i)).toBeInTheDocument();
+  });
+
+  it("closes modal and does not delete when Cancel is clicked", async () => {
+    vi.mocked(quizzesApi.listQuizzes).mockResolvedValue([
+      { id: "1", admin_id: "a", title: "History Quiz", created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    vi.mocked(quizzesApi.deleteQuiz).mockResolvedValue(undefined);
+    renderList();
+    await screen.findByText("History Quiz");
+
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(quizzesApi.deleteQuiz).not.toHaveBeenCalled();
+  });
+
+  it("calls deleteQuiz and closes modal when confirmed", async () => {
+    vi.mocked(quizzesApi.listQuizzes).mockResolvedValue([
+      { id: "1", admin_id: "a", title: "History Quiz", created_at: "2026-01-01T00:00:00Z" },
+    ]);
+    vi.mocked(quizzesApi.deleteQuiz).mockResolvedValue(undefined);
+    renderList();
+    await screen.findByText("History Quiz");
+
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(quizzesApi.deleteQuiz).toHaveBeenCalled();
+      expect(vi.mocked(quizzesApi.deleteQuiz).mock.calls[0][0]).toBe("1");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add `frontend/src/components/ConfirmModal.tsx` — accessible dialog (role=dialog, aria-modal) styled to match the dark UI with Cancel / Delete buttons
- Replace `window.confirm()` in `QuizListPage.tsx` with `pendingDelete` state that controls the modal's visibility; deletion only proceeds on modal confirmation
- Add `ConfirmModal.test.tsx` (4 tests) and update `QuizListPage.test.tsx` (3 new tests covering open, cancel, and confirm flows)

Closes #16

## How to test

1. `docker compose up --build`
2. Log in as admin and navigate to the Quizzes list
3. Click **Delete** on any quiz — a styled modal should appear with the quiz title
4. Click **Cancel** — modal dismisses, no deletion
5. Click **Delete** on a quiz again, then click **Delete** in the modal — quiz is removed