### PR TITLE
feat(#9): player score history — personal results after game

### DIFF
--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -55,6 +55,7 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 		r.Post("/sessions/join", h.JoinSession)
 		r.Get("/sessions/code/{code}", h.GetSessionByCode)
 		r.Get("/sessions/{sessionID}/players", h.ListSessionPlayers)
+		r.Get("/sessions/{sessionID}/players/{playerID}/results", h.GetPlayerResults)
 
 		// WebSocket endpoints
 		r.Get("/ws/host/{sessionCode}", h.HostWebSocket)

--- a/backend/internal/handlers/session.go
+++ b/backend/internal/handlers/session.go
@@ -300,6 +300,84 @@ func (h *Handler) StartSession(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, session)
 }
 
+func (h *Handler) GetPlayerResults(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "sessionID")
+	playerID := chi.URLParam(r, "playerID")
+
+	// Validate IDs are valid UUIDs
+	if _, err := uuid.Parse(sessionID); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid session ID")
+		return
+	}
+	if _, err := uuid.Parse(playerID); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid player ID")
+		return
+	}
+
+	// Fetch player name and score
+	var results models.PlayerResults
+	err := h.db.QueryRow(r.Context(),
+		`SELECT id, name, score FROM game_players WHERE id = $1 AND session_id = $2`,
+		playerID, sessionID,
+	).Scan(&results.PlayerID, &results.Name, &results.Score)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "player not found")
+		return
+	}
+
+	// Calculate rank: number of players with a higher score + 1
+	err = h.db.QueryRow(r.Context(),
+		`SELECT COUNT(*) + 1 FROM game_players WHERE session_id = $1 AND score > $2`,
+		sessionID, results.Score,
+	).Scan(&results.Rank)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to compute rank")
+		return
+	}
+
+	// Fetch per-question breakdown
+	rows, err := h.db.Query(r.Context(), `
+		SELECT
+			q.id,
+			q.text,
+			q.order,
+			ga.option_id,
+			sel.text,
+			ga.is_correct,
+			ga.points,
+			corr.id,
+			corr.text
+		FROM game_answers ga
+		JOIN questions q ON q.id = ga.question_id
+		JOIN options sel ON sel.id = ga.option_id
+		JOIN options corr ON corr.question_id = q.id AND corr.is_correct = TRUE
+		WHERE ga.session_id = $1 AND ga.player_id = $2
+		ORDER BY q.order ASC
+	`, sessionID, playerID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to fetch results")
+		return
+	}
+	defer rows.Close()
+
+	results.Questions = make([]models.PlayerResultQuestion, 0)
+	for rows.Next() {
+		var q models.PlayerResultQuestion
+		if err := rows.Scan(
+			&q.QuestionID, &q.QuestionText, &q.QuestionOrder,
+			&q.SelectedOptionID, &q.SelectedOptionText,
+			&q.IsCorrect, &q.Points,
+			&q.CorrectOptionID, &q.CorrectOptionText,
+		); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to read results")
+			return
+		}
+		results.Questions = append(results.Questions, q)
+	}
+
+	writeJSON(w, http.StatusOK, results)
+}
+
 func generateCode() (string, error) {
 	n, err := rand.Int(rand.Reader, big.NewInt(1_000_000))
 	if err != nil {

--- a/backend/internal/handlers/session_test.go
+++ b/backend/internal/handlers/session_test.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func TestCreateSession_Validation(t *testing.T) {
@@ -68,6 +71,41 @@ func TestJoinSession_Validation(t *testing.T) {
 func TestListSessions_HandlerRegistered(t *testing.T) {
 	h := newTestHandler()
 	var _ http.HandlerFunc = h.ListSessions
+}
+
+func getWithChiParams(sessionID, playerID string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("sessionID", sessionID)
+	rctx.URLParams.Add("playerID", playerID)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestGetPlayerResults_InvalidUUIDs(t *testing.T) {
+	h := newTestHandler()
+
+	validUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+	tests := []struct {
+		name      string
+		sessionID string
+		playerID  string
+	}{
+		{"invalid session ID", "not-a-uuid", validUUID},
+		{"invalid player ID", validUUID, "not-a-uuid"},
+		{"both invalid", "bad", "bad"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := getWithChiParams(tc.sessionID, tc.playerID)
+			w := httptest.NewRecorder()
+			h.GetPlayerResults(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d — body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
 }
 
 func TestGenerateCode(t *testing.T) {

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -101,3 +101,25 @@ type LeaderboardEntry struct {
 	Score    int       `json:"score"`
 	Rank     int       `json:"rank"`
 }
+
+// Player results (personal game summary)
+
+type PlayerResultQuestion struct {
+	QuestionID         uuid.UUID `json:"question_id"`
+	QuestionText       string    `json:"question_text"`
+	QuestionOrder      int       `json:"question_order"`
+	SelectedOptionID   uuid.UUID `json:"selected_option_id"`
+	SelectedOptionText string    `json:"selected_option_text"`
+	CorrectOptionID    uuid.UUID `json:"correct_option_id"`
+	CorrectOptionText  string    `json:"correct_option_text"`
+	IsCorrect          bool      `json:"is_correct"`
+	Points             int       `json:"points"`
+}
+
+type PlayerResults struct {
+	PlayerID  uuid.UUID              `json:"player_id"`
+	Name      string                 `json:"name"`
+	Score     int                    `json:"score"`
+	Rank      int                    `json:"rank"`
+	Questions []PlayerResultQuestion `json:"questions"`
+}

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./client";
-import type { GameSession, GamePlayer, SessionSummary } from "../types";
+import type { GameSession, GamePlayer, SessionSummary, PlayerResults } from "../types";
 
 export async function createSession(quizId: string): Promise<{ session_id: string; code: string }> {
   const { data } = await apiClient.post<{ session_id: string; code: string }>("/sessions", {
@@ -47,5 +47,12 @@ export async function joinSession(code: string, name: string): Promise<JoinSessi
 export async function listSessions(quizId?: string): Promise<SessionSummary[]> {
   const params = quizId ? { quiz_id: quizId } : undefined;
   const { data } = await apiClient.get<SessionSummary[]>("/sessions", { params });
+  return data;
+}
+
+export async function getPlayerResults(sessionId: string, playerId: string): Promise<PlayerResults> {
+  const { data } = await apiClient.get<PlayerResults>(
+    `/sessions/${sessionId}/players/${playerId}/results`
+  );
   return data;
 }

--- a/frontend/src/components/PodiumScreen.tsx
+++ b/frontend/src/components/PodiumScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { PodiumEntry } from "../types";
+import type { PodiumEntry, PlayerResults } from "../types";
 
 interface Props {
   entries: PodiumEntry[];
@@ -9,6 +9,8 @@ interface Props {
   onEnd?: () => void;
   /** Label for the primary action button. */
   endLabel?: string;
+  /** Personal question-by-question results for the current player. */
+  playerResults?: PlayerResults | null;
 }
 
 // Deterministic confetti piece config so SSR/test renders are stable.
@@ -65,7 +67,7 @@ const PODIUM_COLORS = [
 const MEDALS = ["🥇", "🥈", "🥉"];
 const RANK_LABELS = ["2nd", "1st", "3rd"];
 
-export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Dashboard" }: Props) {
+export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Dashboard", playerResults }: Props) {
   const top3 = entries.slice(0, 3);
   const rest = entries.slice(3);
   const confetti = useMemo(() => generateConfetti(80), []);
@@ -156,6 +158,51 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
             </div>
           );
         })()}
+
+        {/* Personal question breakdown (player view only) */}
+        {playerResults && playerResults.questions.length > 0 && (
+          <div className="w-full" data-testid="player-results-breakdown">
+            <h2 className="text-lg font-bold mb-3 text-center">Your Performance</h2>
+            <div className="space-y-2">
+              {playerResults.questions.map((q, i) => (
+                <div
+                  key={q.question_id}
+                  className={`rounded-xl px-4 py-3 flex items-start gap-3 ${
+                    q.is_correct
+                      ? "bg-green-900/30 border border-green-700"
+                      : "bg-red-900/30 border border-red-800"
+                  }`}
+                >
+                  <span className="text-xl mt-0.5 flex-shrink-0">
+                    {q.is_correct ? "✓" : "✗"}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold leading-snug">
+                      {i + 1}. {q.question_text}
+                    </p>
+                    <p className="text-xs text-gray-400 mt-1">
+                      Your answer:{" "}
+                      <span className={q.is_correct ? "text-green-300" : "text-red-300"}>
+                        {q.selected_option_text}
+                      </span>
+                    </p>
+                    {!q.is_correct && (
+                      <p className="text-xs text-gray-400">
+                        Correct:{" "}
+                        <span className="text-green-300">{q.correct_option_text}</span>
+                      </p>
+                    )}
+                  </div>
+                  {q.is_correct && (
+                    <span className="text-green-400 font-black tabular-nums text-sm flex-shrink-0">
+                      +{q.points}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Remaining players (4th+) */}
         {rest.length > 0 && (

--- a/frontend/src/pages/PlayerGamePage.tsx
+++ b/frontend/src/pages/PlayerGamePage.tsx
@@ -1,8 +1,10 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { LeaderboardDisplay } from "../components/LeaderboardDisplay";
 import { PodiumScreen } from "../components/PodiumScreen";
+import { getPlayerResults } from "../api/sessions";
 import type { WsMessage, QuestionPayload, LeaderboardEntry, PodiumEntry } from "../types";
 
 const WS_BASE = import.meta.env.VITE_WS_BASE_URL ?? "ws://localhost:8081";
@@ -84,6 +86,7 @@ function CountdownRing({
 export function PlayerGamePage() {
   const { code } = useParams<{ code: string }>();
   const playerId = sessionStorage.getItem("player_id") ?? "";
+  const sessionId = sessionStorage.getItem("session_id") ?? "";
 
   const [phase, setPhase] = useState<GamePhase>("waiting");
   const [currentQuestion, setCurrentQuestion] = useState<QuestionPayload | null>(null);
@@ -94,6 +97,13 @@ export function PlayerGamePage() {
   const [prevLeaderboard, setPrevLeaderboard] = useState<LeaderboardEntry[]>([]);
   const leaderboardRef = useRef<LeaderboardEntry[]>([]);
   const [podium, setPodium] = useState<PodiumEntry[]>([]);
+
+  const { data: playerResults } = useQuery({
+    queryKey: ["playerResults", sessionId, playerId],
+    queryFn: () => getPlayerResults(sessionId, playerId),
+    enabled: phase === "podium" && !!sessionId && !!playerId,
+    staleTime: Infinity,
+  });
 
   const { send } = useWebSocket({
     url: `${WS_BASE}/api/v1/ws/player/${code}?player_id=${playerId}&name=${encodeURIComponent(
@@ -187,7 +197,7 @@ export function PlayerGamePage() {
 
   // Podium
   if (phase === "podium") {
-    return <PodiumScreen entries={podium} playerId={playerId} />;
+    return <PodiumScreen entries={podium} playerId={playerId} playerResults={playerResults} />;
   }
 
   // Leaderboard

--- a/frontend/src/test/PlayerGamePage.test.tsx
+++ b/frontend/src/test/PlayerGamePage.test.tsx
@@ -2,9 +2,17 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PlayerGamePage } from "../pages/PlayerGamePage";
+import * as sessionsApi from "../api/sessions";
+import type { PlayerResults } from "../types";
+
+vi.mock("../api/sessions", () => ({
+  getPlayerResults: vi.fn(),
+}));
 
 const PLAYER_ID = "player-123";
+const SESSION_ID = "session-456";
 const mockSend = vi.fn();
 let capturedOnMessage: ((msg: unknown) => void) | null = null;
 
@@ -18,18 +26,29 @@ vi.mock("../hooks/useWebSocket", () => ({
 beforeEach(() => {
   mockSend.mockClear();
   capturedOnMessage = null;
+  vi.mocked(sessionsApi.getPlayerResults).mockResolvedValue({
+    player_id: PLAYER_ID,
+    name: "Alice",
+    score: 2700,
+    rank: 1,
+    questions: [],
+  } as PlayerResults);
   // Simulate player identity in sessionStorage.
   sessionStorage.setItem("player_id", PLAYER_ID);
   sessionStorage.setItem("player_name", "Alice");
+  sessionStorage.setItem("session_id", SESSION_ID);
 });
 
 function renderPlayerGame(code = "123456") {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <MemoryRouter initialEntries={[`/game/${code}/play`]}>
-      <Routes>
-        <Route path="/game/:code/play" element={<PlayerGamePage />} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/game/${code}/play`]}>
+        <Routes>
+          <Route path="/game/:code/play" element={<PlayerGamePage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -172,5 +191,58 @@ describe("PlayerGamePage", () => {
     const link = screen.getByRole("link", { name: /join a new game/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/join");
+  });
+
+  it("fetches player results when podium is shown", async () => {
+    const fakeResults: PlayerResults = {
+      player_id: PLAYER_ID,
+      name: "Alice",
+      score: 2700,
+      rank: 1,
+      questions: [
+        {
+          question_id: "q-1",
+          question_text: "What is 2+2?",
+          question_order: 1,
+          selected_option_id: "o-2",
+          selected_option_text: "4",
+          correct_option_id: "o-2",
+          correct_option_text: "4",
+          is_correct: true,
+          points: 900,
+        },
+        {
+          question_id: "q-2",
+          question_text: "Capital of France?",
+          question_order: 2,
+          selected_option_id: "o-3",
+          selected_option_text: "Berlin",
+          correct_option_id: "o-4",
+          correct_option_text: "Paris",
+          is_correct: false,
+          points: 0,
+        },
+      ],
+    };
+    vi.mocked(sessionsApi.getPlayerResults).mockResolvedValue(fakeResults);
+
+    renderPlayerGame();
+    act(() =>
+      capturedOnMessage!({
+        type: "podium",
+        payload: {
+          entries: [{ player_id: PLAYER_ID, name: "Alice", score: 2700, rank: 1 }],
+        },
+      }),
+    );
+
+    expect(sessionsApi.getPlayerResults).toHaveBeenCalledWith(SESSION_ID, PLAYER_ID);
+
+    // Wait for query to resolve and results to render
+    await screen.findByTestId("player-results-breakdown");
+    expect(screen.getByText(/What is 2\+2\?/)).toBeInTheDocument();
+    expect(screen.getByText(/Capital of France\?/)).toBeInTheDocument();
+    expect(screen.getByText("+900")).toBeInTheDocument();
+    expect(screen.getByText("Paris")).toBeInTheDocument();
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -115,3 +115,23 @@ export interface PodiumEntry {
   score: number;
   rank: number;
 }
+
+export interface PlayerResultQuestion {
+  question_id: string;
+  question_text: string;
+  question_order: number;
+  selected_option_id: string;
+  selected_option_text: string;
+  correct_option_id: string;
+  correct_option_text: string;
+  is_correct: boolean;
+  points: number;
+}
+
+export interface PlayerResults {
+  player_id: string;
+  name: string;
+  score: number;
+  rank: number;
+  questions: PlayerResultQuestion[];
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/sessions/{sessionID}/players/{playerID}/results` endpoint (no auth required) that returns a player's final rank, total score, and per-question breakdown (question text, selected answer, correct answer, points earned)
- Adds `PlayerResults` and `PlayerResultQuestion` models on backend and matching TypeScript types on frontend
- `PodiumScreen` now accepts an optional `playerResults` prop and renders a "Your Performance" card showing each question's outcome
- `PlayerGamePage` fetches the player's results via TanStack Query when the podium phase starts and passes them to `PodiumScreen`

## How to test

1. Start the stack: `docker compose up --build`
2. Create a quiz, start a session, join as a player, play through all questions
3. On the podium screen, the player should see a "Your Performance" section below the podium listing each question with ✓/✗, their selected answer, the correct answer (if wrong), and points earned

Closes #9