### PR TITLE
feat(#11): mobile-responsive UI for player screens

### DIFF
--- a/frontend/src/components/LeaderboardDisplay.tsx
+++ b/frontend/src/components/LeaderboardDisplay.tsx
@@ -116,14 +116,14 @@ export function LeaderboardDisplay({
                 : "bg-gray-900",
             ].join(" ")}
           >
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 min-w-0">
               <span className="w-8 text-center font-black text-lg shrink-0">{rank}</span>
-              <span className="font-medium">{entry.name}</span>
+              <span className="font-medium truncate">{entry.name}</span>
               {isHighlighted && (
-                <span className="text-xs text-indigo-400">(you)</span>
+                <span className="text-xs text-indigo-400 shrink-0">(you)</span>
               )}
             </div>
-            <span className="font-bold text-indigo-300 tabular-nums">{entry.score}</span>
+            <span className="font-bold text-indigo-300 tabular-nums shrink-0 ml-2">{entry.score}</span>
           </div>
         );
       })}

--- a/frontend/src/components/PodiumScreen.tsx
+++ b/frontend/src/components/PodiumScreen.tsx
@@ -73,7 +73,7 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
   const confetti = useMemo(() => generateConfetti(80), []);
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center px-4 overflow-hidden relative">
+    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-start px-4 py-8 sm:justify-center sm:py-0 overflow-y-auto relative">
       {/* Confetti */}
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
         {confetti.map((piece) => (
@@ -218,18 +218,18 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
                       : "bg-gray-900"
                   }`}
                 >
-                  <div className="flex items-center gap-3">
-                    <span className="w-8 text-center font-bold text-gray-400">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="w-8 text-center font-bold text-gray-400 shrink-0">
                       #{entry.rank}
                     </span>
-                    <span className="font-medium">
+                    <span className="font-medium truncate">
                       {entry.name}
                       {isSelf && (
                         <span className="ml-2 text-xs text-indigo-400">(you)</span>
                       )}
                     </span>
                   </div>
-                  <span className="font-bold text-indigo-300 tabular-nums">
+                  <span className="font-bold text-indigo-300 tabular-nums shrink-0 ml-2">
                     {entry.score}
                   </span>
                 </div>
@@ -247,15 +247,12 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
             {endLabel}
           </button>
         ) : (
-          <p className="text-gray-500 text-sm">
-            Want to play again?{" "}
-            <a
-              href="/join"
-              className="text-indigo-400 hover:text-indigo-300 transition"
-            >
-              Join a new game
-            </a>
-          </p>
+          <a
+            href="/join"
+            className="w-full block text-center bg-indigo-600 hover:bg-indigo-500 text-white font-bold py-4 rounded-xl transition text-lg"
+          >
+            Play again
+          </a>
         )}
       </div>
     </div>

--- a/frontend/src/pages/PlayerLobbyPage.tsx
+++ b/frontend/src/pages/PlayerLobbyPage.tsx
@@ -121,7 +121,10 @@ export function PlayerLobbyPage() {
             The code <span className="font-mono text-indigo-400">{code}</span> doesn't match any
             active game.
           </p>
-          <a href="/join" className="inline-block text-indigo-400 hover:text-indigo-300 text-sm">
+          <a
+            href="/join"
+            className="inline-block bg-indigo-600 hover:bg-indigo-500 text-white font-semibold px-6 py-3 rounded-lg transition"
+          >
             ← Try a different code
           </a>
         </div>

--- a/frontend/src/test/LeaderboardDisplay.test.tsx
+++ b/frontend/src/test/LeaderboardDisplay.test.tsx
@@ -123,4 +123,22 @@ describe("LeaderboardDisplay", () => {
     // Bob is now rank 1
     expect(screen.getByText("🥇")).toBeInTheDocument();
   });
+
+  // --- Mobile responsiveness ---
+
+  it("renders long player names without crashing", () => {
+    const longNameEntries = [
+      { player_id: "p1", name: "AVeryLongPlayerNameThatCouldOverflowOnMobile", score: 2000, rank: 1 },
+    ];
+    render(<LeaderboardDisplay entries={longNameEntries} />);
+    expect(screen.getByText("AVeryLongPlayerNameThatCouldOverflowOnMobile")).toBeInTheDocument();
+  });
+
+  it("score element has shrink-0 class to prevent it being squeezed by long names", () => {
+    render(<LeaderboardDisplay entries={entries} />);
+    // Find all score elements — they should have shrink-0 so they don't get pushed off screen
+    const scores = screen.getAllByText(/\d+/);
+    const scoreEl = scores.find((el) => el.textContent === "2000");
+    expect(scoreEl?.className).toMatch(/shrink-0/);
+  });
 });

--- a/frontend/src/test/PlayerGamePage.test.tsx
+++ b/frontend/src/test/PlayerGamePage.test.tsx
@@ -188,7 +188,7 @@ describe("PlayerGamePage", () => {
         },
       }),
     );
-    const link = screen.getByRole("link", { name: /join a new game/i });
+    const link = screen.getByRole("link", { name: /play again/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/join");
   });

--- a/frontend/src/test/PodiumScreen.test.tsx
+++ b/frontend/src/test/PodiumScreen.test.tsx
@@ -88,7 +88,7 @@ describe("PodiumScreen", () => {
 
   it("shows join link when no onEnd is provided (player view)", () => {
     render(<PodiumScreen entries={entries} />);
-    expect(screen.getByRole("link", { name: /join a new game/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /play again/i })).toBeInTheDocument();
   });
 
   it("does not render the end button in player view", () => {
@@ -109,5 +109,27 @@ describe("PodiumScreen", () => {
   it("uses custom endLabel on the button", () => {
     render(<PodiumScreen entries={entries} onEnd={vi.fn()} endLabel="End Session" />);
     expect(screen.getByRole("button", { name: "End Session" })).toBeInTheDocument();
+  });
+
+  // --- Mobile responsiveness ---
+
+  it("play again link is a block-level element for full-width tap target", () => {
+    render(<PodiumScreen entries={entries} />);
+    const link = screen.getByRole("link", { name: /play again/i });
+    // Should have w-full and block classes for a large mobile tap target
+    expect(link.className).toMatch(/w-full/);
+    expect(link.className).toMatch(/block/);
+  });
+
+  it("rest player names have truncate class to prevent horizontal overflow", () => {
+    const longNameEntries = [
+      { player_id: "p1", name: "Alice", score: 3000, rank: 1 },
+      { player_id: "p2", name: "Bob", score: 2000, rank: 2 },
+      { player_id: "p3", name: "Carol", score: 1000, rank: 3 },
+      { player_id: "p4", name: "AVeryLongPlayerNameThatCouldOverflowOnMobile", score: 500, rank: 4 },
+    ];
+    render(<PodiumScreen entries={longNameEntries} />);
+    // The 4th-place player should render without breaking layout
+    expect(screen.getByText("AVeryLongPlayerNameThatCouldOverflowOnMobile")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- **PodiumScreen**: removed `overflow-hidden` that was clipping content on phones; changed to `overflow-y-auto justify-start py-8` so long result lists scroll correctly on mobile
- **PodiumScreen**: replaced inline "Join a new game" text link with a full-width block `<a>` (`w-full block py-4`) for a proper 44px+ tap target
- **LeaderboardDisplay**: added `min-w-0` + `truncate` to player name spans and `shrink-0 ml-2` to scores to prevent long names from causing horizontal overflow
- **PodiumScreen rest-players**: same `min-w-0` / `truncate` / `shrink-0` fix for 4th+ player rows
- **PlayerLobbyPage**: upgraded the "Try a different code" error-state link from a small inline text link to a full `px-6 py-3` button

Closes #11

## What was already mobile-ready (no changes needed)
- JoinPage: already uses `max-w-sm`, `py-3` inputs/buttons
- PlayerLobbyPage main flow: `max-w-sm px-4`, `flex-col` layout
- PlayerGamePage question phase: `min-h-[80px]` options, `w-full` containers
- All screens: no fixed widths wider than viewport

## How to test
1. Open any player screen in Chrome DevTools at 375px width (iPhone SE) and 390px (iPhone 14)
2. Join a game and verify: join page, lobby, question screen, answer reveal, leaderboard, podium all display correctly
3. Check no horizontal scrollbar appears on any player screen
4. Verify tap targets on buttons/links are visually large (≥ 44px)
5. On the podium screen with many players, scroll down — content should not be clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)