### PR TITLE
fix(#45): host game page single-column vertical layout

### DIFF
--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -200,7 +200,7 @@ export function HostGamePage() {
       </div>
 
       {currentQuestion && (
-        <div className="flex-1 flex flex-col items-center px-6 py-8 max-w-3xl mx-auto w-full">
+        <div className="flex-1 flex flex-col items-center px-6 py-8 max-w-2xl mx-auto w-full">
           {/* Question text */}
           <div className="w-full bg-gray-900 rounded-2xl p-8 text-center mb-6">
             <p className="text-2xl font-bold leading-snug">
@@ -215,8 +215,8 @@ export function HostGamePage() {
             </p>
           )}
 
-          {/* Options grid */}
-          <div className="w-full grid grid-cols-2 gap-4">
+          {/* Options list */}
+          <div className="w-full flex flex-col gap-4">
             {currentQuestion.question.options.map((opt, i) => {
               const isCorrect = opt.is_correct;
               const revealed = phase === "reveal";


### PR DESCRIPTION
## Summary

- Replaced `grid grid-cols-2 gap-4` on the answer options container with `flex flex-col gap-4` so all options stack vertically at full width
- Reduced outer container from `max-w-3xl` to `max-w-2xl` for better readability on wide screens

Closes #45

## Test plan

- [ ] Launch a game as host and confirm question text and answer options are stacked vertically (no side-by-side split)
- [ ] Check at 375px (mobile) — all options readable and full width
- [ ] Check at 1440px (desktop) — options capped at `max-w-2xl`, no dead space
- [ ] Answer reveal still highlights correct option correctly
- [ ] All 88 frontend tests pass (`./scripts/check.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)