### PR TITLE
feat(#47): mobile-responsive admin UI

### DIFF
--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -34,14 +34,14 @@ export function AdminDashboardPage() {
 
       {/* Header */}
       <header
-        className="relative z-20 px-6 py-4 flex items-center justify-between"
+        className="relative z-20 px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between"
         style={{
           background: "linear-gradient(180deg, rgba(30, 15, 50, 0.95) 0%, rgba(20, 10, 40, 0.9) 100%)",
           borderBottom: "1px solid rgba(245, 200, 66, 0.2)",
         }}
       >
         {/* Logo + Nav */}
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-3 sm:gap-6">
           <motion.div className="flex items-center gap-2" initial={{ opacity: 0, x: -10 }} animate={{ opacity: 1, x: 0 }}>
             <div className="relative">
               <CrescentIcon className="w-8 h-8" style={{ color: "#f5c842" }} />
@@ -50,10 +50,10 @@ export function AdminDashboardPage() {
             <span className="text-xl font-black" style={{ color: "#f5c842" }}>Iftaroot</span>
           </motion.div>
 
-          <nav className="flex items-center gap-1">
+          <nav className="flex items-center gap-0.5 sm:gap-1">
             <NavLink to="/admin/quizzes"
               className={({ isActive }) =>
-                `px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                `px-2.5 sm:px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
                   isActive
                     ? "text-[#1a0a2e] font-bold"
                     : "hover:opacity-100 opacity-70'"}` }
@@ -64,7 +64,7 @@ export function AdminDashboardPage() {
             </NavLink>
             <NavLink to="/admin/history"
               className={({ isActive }) =>
-                `px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                `px-2.5 sm:px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
                   isActive ? "font-bold" : "opacity-70 hover:opacity-100"
                 }`}
               style={({ isActive }) => isActive
@@ -76,19 +76,19 @@ export function AdminDashboardPage() {
         </div>
 
         {/* Right side */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 sm:gap-4">
           {admin?.email && (
-            <span className="text-sm" style={{ color: "rgba(255,255,255,0.6)" }}>{admin.email}</span>
+            <span className="hidden sm:block text-sm truncate max-w-[180px]" style={{ color: "rgba(255,255,255,0.6)" }}>{admin.email}</span>
           )}
           {isHostingGame && activeSession ? (
             <motion.button onClick={handleEndGame} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}
-              className="text-sm font-bold px-4 py-2 rounded-lg transition"
+              className="text-sm font-bold px-3 sm:px-4 py-2 rounded-lg transition"
               style={{ background: "rgba(244,67,54,0.2)", color: "#f44336", border: "1px solid rgba(244,67,54,0.4)" }}>
               End Game
             </motion.button>
           ) : (
             <motion.button onClick={handleLogout} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}
-              className="text-sm font-medium px-4 py-2 rounded-lg transition"
+              className="text-sm font-medium px-3 sm:px-4 py-2 rounded-lg transition"
               style={{ color: "rgba(255,255,255,0.6)", border: "1px solid rgba(255,255,255,0.15)" }}>
               Sign out
             </motion.button>
@@ -96,7 +96,7 @@ export function AdminDashboardPage() {
         </div>
       </header>
 
-      <main className="relative z-10 max-w-5xl mx-auto px-6 py-10">
+      <main className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -178,11 +178,11 @@ export function HostGamePage() {
       <div className="ramadan-pattern" />
 
       {/* Top bar */}
-      <div className="relative z-20 px-8 py-4 flex items-center justify-between"
+      <div className="relative z-20 px-4 sm:px-8 py-3 sm:py-4 flex items-center justify-between"
         style={{ background: "linear-gradient(180deg, rgba(30,15,50,0.95) 0%, rgba(20,10,40,0.9) 100%)", borderBottom: "1px solid rgba(245,200,66,0.2)" }}>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           <CrescentIcon className="w-6 h-6" style={{ color: "#f5c842" }} />
-          <span className="text-lg font-bold" style={{ color: "#f5c842" }}>Iftaroot Live</span>
+          <span className="hidden sm:inline text-lg font-bold" style={{ color: "#f5c842" }}>Iftaroot Live</span>
           <span className="font-mono text-sm px-2 py-0.5 rounded" style={{ background: "rgba(245,200,66,0.1)", color: "rgba(255,255,255,0.5)" }}>{code}</span>
         </div>
         {currentQuestion && (
@@ -190,16 +190,16 @@ export function HostGamePage() {
             Question <span className="font-bold text-white">{currentQuestion.question_index + 1}</span> / {currentQuestion.total_questions}
           </div>
         )}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5 sm:gap-2">
           <Users className="w-4 h-4" style={{ color: "#2196f3" }} />
           <span className="font-bold text-white">{answeredCount}</span>
-          <span className="text-sm" style={{ color: "rgba(255,255,255,0.5)" }}>answered</span>
-          <span className={`ml-3 w-2 h-2 rounded-full ${wsReady ? "bg-green-400" : "bg-yellow-400"} animate-pulse`} />
+          <span className="hidden sm:inline text-sm" style={{ color: "rgba(255,255,255,0.5)" }}>answered</span>
+          <span className={`ml-1 sm:ml-3 w-2 h-2 rounded-full ${wsReady ? "bg-green-400" : "bg-yellow-400"} animate-pulse`} />
         </div>
       </div>
 
       {currentQuestion && (
-        <div className="relative z-10 flex-1 flex flex-col gap-5 p-6 max-w-2xl mx-auto w-full">
+        <div className="relative z-10 flex-1 flex flex-col gap-5 p-4 sm:p-6 max-w-2xl mx-auto w-full">
           {/* Progress bar */}
           <motion.div initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
             <div className="flex items-center justify-between mb-2">

--- a/frontend/src/pages/HostLobbyPage.tsx
+++ b/frontend/src/pages/HostLobbyPage.tsx
@@ -109,7 +109,7 @@ export function HostLobbyPage() {
     <div className="min-h-screen w-full relative overflow-hidden" style={{ background: "#1a0a2e" }}>
       <div className="ramadan-pattern" />
 
-      <div className="relative z-10 min-h-screen flex flex-col items-center px-6 py-12 max-w-2xl mx-auto">
+      <div className="relative z-10 min-h-screen flex flex-col items-center px-4 sm:px-6 py-8 sm:py-12 max-w-2xl mx-auto">
         {/* Animated lanterns */}
         <div className="absolute top-8 left-1/2 -translate-x-1/2 flex gap-32">
           {[{ delay: 0 }, { delay: 0.5 }].map((l, i) => (
@@ -127,7 +127,7 @@ export function HostLobbyPage() {
               <CrescentIcon className="w-6 h-6" style={{ color: "#f5c842" }} />
               <p className="text-sm font-medium uppercase tracking-widest" style={{ color: "rgba(255,255,255,0.6)" }}>Room Code</p>
             </div>
-            <h1 className="text-8xl font-black tracking-widest" style={{
+            <h1 className="text-5xl sm:text-8xl font-black tracking-widest" style={{
               color: "#f5c842",
               textShadow: "0 0 30px rgba(245,200,66,0.6), 0 4px 20px rgba(0,0,0,0.5)",
             }}>

--- a/frontend/src/pages/SessionHistoryPage.tsx
+++ b/frontend/src/pages/SessionHistoryPage.tsx
@@ -84,17 +84,17 @@ export function SessionHistoryPage() {
         <div className="space-y-3">
           {sessions.map((s, i) => (
             <motion.div key={s.id}
-              className="px-5 py-4 rounded-2xl flex items-center gap-4"
+              className="px-4 sm:px-5 py-4 rounded-2xl flex items-start sm:items-center gap-3 sm:gap-4"
               style={{
                 background: "linear-gradient(135deg, rgba(42,20,66,0.7) 0%, rgba(30,15,50,0.8) 100%)",
                 border: "1px solid rgba(245,200,66,0.12)",
               }}
               initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.04 }}>
 
-              {/* Quiz title */}
+              {/* Quiz title + meta */}
               <div className="flex-1 min-w-0">
                 <p className="font-bold text-white truncate">{s.quiz_title}</p>
-                <div className="flex items-center gap-4 mt-1">
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1">
                   <div className="flex items-center gap-1 text-xs" style={{ color: "rgba(255,255,255,0.45)" }}>
                     <Hash className="w-3 h-3" />
                     <span className="font-mono">{s.code}</span>
@@ -110,31 +110,31 @@ export function SessionHistoryPage() {
                 </div>
               </div>
 
-              {/* Status */}
-              <StatusBadge status={s.status} />
-
-              {/* Actions */}
-              {s.status === "waiting" && (
-                <div className="flex items-center gap-2">
-                  <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                    <Link to={`/admin/host/${s.code}`}
-                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold"
-                      style={{ background: "rgba(245,200,66,0.15)", color: "#f5c842", border: "1px solid rgba(245,200,66,0.3)" }}>
-                      <ExternalLink className="w-3.5 h-3.5" />
-                      Resume
-                    </Link>
-                  </motion.div>
-                  <motion.button
-                    onClick={() => setPendingDelete(s.id)}
-                    disabled={deleteMutation.isPending}
-                    aria-label="Delete"
-                    className="p-1.5 rounded-lg transition disabled:opacity-50"
-                    style={{ background: "rgba(244,67,54,0.1)", color: "#f44336", border: "1px solid rgba(244,67,54,0.25)" }}
-                    whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                    <Trash2 className="w-3.5 h-3.5" />
-                  </motion.button>
-                </div>
-              )}
+              {/* Status + actions — stacked on mobile, inline on sm+ */}
+              <div className="flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
+                <StatusBadge status={s.status} />
+                {s.status === "waiting" && (
+                  <div className="flex items-center gap-2">
+                    <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                      <Link to={`/admin/host/${s.code}`}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold"
+                        style={{ background: "rgba(245,200,66,0.15)", color: "#f5c842", border: "1px solid rgba(245,200,66,0.3)" }}>
+                        <ExternalLink className="w-3.5 h-3.5" />
+                        Resume
+                      </Link>
+                    </motion.div>
+                    <motion.button
+                      onClick={() => setPendingDelete(s.id)}
+                      disabled={deleteMutation.isPending}
+                      aria-label="Delete"
+                      className="p-1.5 rounded-lg transition disabled:opacity-50"
+                      style={{ background: "rgba(244,67,54,0.1)", color: "#f44336", border: "1px solid rgba(244,67,54,0.25)" }}
+                      whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </motion.button>
+                  </div>
+                )}
+              </div>
             </motion.div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- **AdminDashboardPage (nav bar)**: reduce padding to `px-4 sm:px-6`, hide admin email on mobile (`hidden sm:block truncate`), tighten nav/button gaps — all controls fit at 375 px without overflow
- **SessionHistoryPage**: metadata row switched to `flex-wrap` so code/date/player count don't overflow; status badge + actions use `flex-col sm:flex-row` so they stack vertically on mobile instead of pushing content off-screen
- **HostLobbyPage**: room code `text-5xl sm:text-8xl` prevents the 6-char code from overflowing narrow viewports; container padding reduced on mobile
- **HostGamePage**: header padding `px-4 sm:px-8`, "Iftaroot Live" label and "answered" text hidden on mobile (`hidden sm:inline`), content padding `p-4 sm:p-6`

No layout changes on desktop (sm+ breakpoint restores original sizing).

Closes #47

## Test plan

- [x] Resize browser to 375 px — no horizontal scrollbar on any admin screen
- [x] Nav bar: logo + Quizzes + History + Sign out button all visible and tappable at 375 px
- [x] Session history: long quiz title truncates, metadata wraps cleanly, status/actions stack below title on mobile
- [x] Host Lobby: room code fits within viewport at 375 px
- [x] Host Game: header shows code + Q counter + answer count without overflow at 375 px
- [x] All 88 frontend tests pass (`./scripts/check.sh`)