### PR TITLE
feat(#44): fast player disconnect detection

### DIFF
--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -27,8 +27,8 @@ func newUpgrader(frontendURL string) *websocket.Upgrader {
 
 const (
 	writeWait      = 10 * time.Second
-	pongWait       = 60 * time.Second
-	pingPeriod     = (pongWait * 9) / 10
+	pongWait       = 5 * time.Second // fast disconnect detection; frontend sends close on pagehide
+	pingPeriod     = 3 * time.Second // must be < pongWait
 	maxMessageSize = 512
 )
 

--- a/backend/internal/handlers/websocket_test.go
+++ b/backend/internal/handlers/websocket_test.go
@@ -1,0 +1,24 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWebSocketTimeoutConfig ensures disconnect detection is fast enough for
+// a responsive lobby. pongWait drives worst-case detection time when the
+// browser doesn't send a clean close frame (mobile suspend, crash, etc.).
+func TestWebSocketTimeoutConfig(t *testing.T) {
+	const maxAcceptablePongWait = 15 * time.Second
+
+	if pongWait > maxAcceptablePongWait {
+		t.Errorf("pongWait=%v is too large; ghost players would linger for >%v after disconnect",
+			pongWait, maxAcceptablePongWait)
+	}
+	if pingPeriod >= pongWait {
+		t.Errorf("pingPeriod=%v must be less than pongWait=%v", pingPeriod, pongWait)
+	}
+	if writeWait <= 0 {
+		t.Error("writeWait must be positive")
+	}
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -62,7 +62,13 @@ export function useWebSocket({
       }
     };
 
+    // Close proactively on tab close / navigation so the server detects the
+    // disconnect immediately rather than waiting for the ping/pong timeout.
+    const handlePageHide = () => ws.close();
+    window.addEventListener("pagehide", handlePageHide);
+
     return () => {
+      window.removeEventListener("pagehide", handlePageHide);
       ws.close();
     };
   }, [url, enabled]); // callbacks intentionally excluded — they live in refs

--- a/frontend/src/test/useWebSocket.test.ts
+++ b/frontend/src/test/useWebSocket.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useWebSocket } from "../hooks/useWebSocket";
+import type { WsMessage } from "../types";
+
+// Capture the WebSocket instance created by the hook so we can assert on it.
+let lastWsInstance: MockWebSocket | null = null;
+
+class MockWebSocket {
+  close = vi.fn();
+  send = vi.fn();
+  readyState = 1; // OPEN
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+
+  constructor() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    lastWsInstance = this;
+  }
+}
+
+const noop = (_: WsMessage) => {};
+
+describe("useWebSocket", () => {
+  beforeEach(() => {
+    lastWsInstance = null;
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers a pagehide listener that closes the socket", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    renderHook(() =>
+      useWebSocket({ url: "ws://test/socket", onMessage: noop, enabled: true }),
+    );
+
+    const pagehideCall = addSpy.mock.calls.find((c) => c[0] === "pagehide");
+    expect(pagehideCall).toBeDefined();
+
+    window.dispatchEvent(new Event("pagehide"));
+    expect(lastWsInstance!.close).toHaveBeenCalled();
+
+    addSpy.mockRestore();
+  });
+
+  it("removes the pagehide listener on cleanup", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() =>
+      useWebSocket({ url: "ws://test/socket", onMessage: noop, enabled: true }),
+    );
+
+    unmount();
+
+    const removedPagehide = removeSpy.mock.calls.find(
+      (c) => c[0] === "pagehide",
+    );
+    expect(removedPagehide).toBeDefined();
+
+    removeSpy.mockRestore();
+  });
+
+  it("closes the socket on component unmount", () => {
+    const { unmount } = renderHook(() =>
+      useWebSocket({ url: "ws://test/socket", onMessage: noop, enabled: true }),
+    );
+
+    unmount();
+    expect(lastWsInstance!.close).toHaveBeenCalled();
+  });
+
+  it("does not open a socket when enabled=false", () => {
+    renderHook(() =>
+      useWebSocket({
+        url: "ws://test/socket",
+        onMessage: noop,
+        enabled: false,
+      }),
+    );
+
+    expect(lastWsInstance).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary

- **`pagehide` listener** in `useWebSocket` proactively closes the WebSocket on tab close/navigation so the server detects disconnects immediately (no waiting for ping/pong cycle)
- **Reduced timeouts**: `pongWait` 60s → 5s, `pingPeriod` 60s → 3s so abrupt disconnects (mobile suspend, crash, network drop) are detected within 5s instead of a minute
- Desktop tab close already sends a clean close frame; the pong timeout is only the fallback for mobile/crash/network drop scenarios

## Tests

- `backend/internal/handlers/websocket_test.go` — asserts `pongWait ≤ 15s` and `pingPeriod < pongWait`
- `frontend/src/test/useWebSocket.test.ts` — 4 tests covering: pagehide listener registration + socket close, listener removal on unmount, socket close on unmount, no socket when `enabled=false`

## How to test

1. Start a session and have a player join the lobby
2. Close the player's browser tab — the host lobby should remove the player within ~1s
3. Kill the player's network — the host lobby should remove the player within ~5s