### PR TITLE
feat(#32): collapse score breakdown behind 'See how you scored' toggle

### DIFF
--- a/frontend/src/components/PodiumScreen.tsx
+++ b/frontend/src/components/PodiumScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { motion } from "motion/react";
 import { Trophy, Sparkles } from "lucide-react";
 import { LanternIcon, CrescentIcon } from "./icons";
@@ -103,6 +103,7 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
   const confetti = useMemo(() => generateConfetti(30), []);
   const myEntry = entries.find((e) => e.player_id === playerId);
   const isChampion = myEntry?.rank === 1;
+  const [showBreakdown, setShowBreakdown] = useState(false);
 
   return (
     <div className="min-h-screen w-full relative overflow-hidden" style={{ background: "#1a0a2e" }}>
@@ -203,33 +204,57 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
           </div>
         )}
 
-        {/* Personal question breakdown */}
+        {/* Personal question breakdown — hidden until player taps "See how you scored" */}
         {playerResults && playerResults.questions.length > 0 && (
-          <div className="mb-6" data-testid="player-results-breakdown">
-            <h2 className="text-lg font-bold mb-3 text-center text-white">Your Performance</h2>
-            <div className="space-y-2">
-              {playerResults.questions.map((q, i) => (
-                <div key={q.question_id} className="rounded-xl px-4 py-3 flex items-start gap-3"
-                  style={{
-                    background: q.is_correct ? "rgba(76,175,80,0.15)" : "rgba(244,67,54,0.15)",
-                    border: `1px solid ${q.is_correct ? "rgba(76,175,80,0.4)" : "rgba(244,67,54,0.4)"}`,
-                  }}>
-                  <span className="text-xl mt-0.5 flex-shrink-0">{q.is_correct ? "✓" : "✗"}</span>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-white leading-snug">{i + 1}. {q.question_text}</p>
-                    <p className="text-xs mt-1" style={{ color: "rgba(255,255,255,0.6)" }}>
-                      Your answer: <span style={{ color: q.is_correct ? "#4caf50" : "#f44336" }}>{q.selected_option_text}</span>
-                    </p>
-                    {!q.is_correct && (
-                      <p className="text-xs" style={{ color: "rgba(255,255,255,0.6)" }}>
-                        Correct: <span style={{ color: "#4caf50" }}>{q.correct_option_text}</span>
-                      </p>
-                    )}
+          <div className="mb-6">
+            {!showBreakdown && (
+              <motion.button
+                onClick={() => setShowBreakdown(true)}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                className="w-full py-3 rounded-xl font-bold text-base"
+                style={{
+                  background: "rgba(245,200,66,0.12)",
+                  border: "2px solid rgba(245,200,66,0.4)",
+                  color: "#f5c842",
+                }}
+              >
+                See how you scored
+              </motion.button>
+            )}
+            {showBreakdown && (
+                <motion.div
+                  data-testid="player-results-breakdown"
+                  initial={{ opacity: 0, y: -8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3, ease: "easeOut" }}
+                >
+                  <h2 className="text-lg font-bold mb-3 text-center text-white">Your Performance</h2>
+                  <div className="space-y-2">
+                    {playerResults.questions.map((q, i) => (
+                      <div key={q.question_id} className="rounded-xl px-4 py-3 flex items-start gap-3"
+                        style={{
+                          background: q.is_correct ? "rgba(76,175,80,0.15)" : "rgba(244,67,54,0.15)",
+                          border: `1px solid ${q.is_correct ? "rgba(76,175,80,0.4)" : "rgba(244,67,54,0.4)"}`,
+                        }}>
+                        <span className="text-xl mt-0.5 flex-shrink-0">{q.is_correct ? "✓" : "✗"}</span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-white leading-snug">{i + 1}. {q.question_text}</p>
+                          <p className="text-xs mt-1" style={{ color: "rgba(255,255,255,0.6)" }}>
+                            Your answer: <span style={{ color: q.is_correct ? "#4caf50" : "#f44336" }}>{q.selected_option_text}</span>
+                          </p>
+                          {!q.is_correct && (
+                            <p className="text-xs" style={{ color: "rgba(255,255,255,0.6)" }}>
+                              Correct: <span style={{ color: "#4caf50" }}>{q.correct_option_text}</span>
+                            </p>
+                          )}
+                        </div>
+                        {q.is_correct && <span className="font-black tabular-nums text-sm shrink-0" style={{ color: "#4caf50" }}>+{q.points}</span>}
+                      </div>
+                    ))}
                   </div>
-                  {q.is_correct && <span className="font-black tabular-nums text-sm shrink-0" style={{ color: "#4caf50" }}>+{q.points}</span>}
-                </div>
-              ))}
-            </div>
+                </motion.div>
+            )}
           </div>
         )}
 

--- a/frontend/src/test/PlayerGamePage.test.tsx
+++ b/frontend/src/test/PlayerGamePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -311,7 +311,9 @@ describe("PlayerGamePage", () => {
 
     expect(sessionsApi.getPlayerResults).toHaveBeenCalledWith(SESSION_ID, PLAYER_ID);
 
-    // Wait for query to resolve and results to render
+    // Wait for query to resolve — "See how you scored" button appears once results are ready
+    const seeScoreBtn = await screen.findByRole("button", { name: /see how you scored/i });
+    fireEvent.click(seeScoreBtn);
     await screen.findByTestId("player-results-breakdown");
     expect(screen.getByText(/What is 2\+2\?/)).toBeInTheDocument();
     expect(screen.getByText(/Capital of France\?/)).toBeInTheDocument();

--- a/frontend/src/test/PodiumScreen.test.tsx
+++ b/frontend/src/test/PodiumScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { PodiumScreen } from "../components/PodiumScreen";
 
@@ -109,6 +109,51 @@ describe("PodiumScreen", () => {
   it("uses custom endLabel on the button", () => {
     render(<PodiumScreen entries={entries} onEnd={vi.fn()} endLabel="End Session" />);
     expect(screen.getByRole("button", { name: "End Session" })).toBeInTheDocument();
+  });
+
+  // --- Score breakdown toggle ---
+
+  const playerResults = {
+    player_id: "p1",
+    name: "Alice",
+    score: 3000,
+    rank: 1,
+    questions: [
+      {
+        question_id: "q1",
+        question_text: "What is 2+2?",
+        question_order: 1,
+        selected_option_id: "o1",
+        selected_option_text: "4",
+        correct_option_id: "o1",
+        correct_option_text: "4",
+        is_correct: true,
+        points: 900,
+      },
+    ],
+  };
+
+  it("hides the breakdown by default and shows 'See how you scored' button", () => {
+    render(<PodiumScreen entries={entries} playerResults={playerResults} />);
+    expect(screen.queryByTestId("player-results-breakdown")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /see how you scored/i })).toBeInTheDocument();
+  });
+
+  it("reveals the breakdown after clicking 'See how you scored'", async () => {
+    render(<PodiumScreen entries={entries} playerResults={playerResults} />);
+    fireEvent.click(screen.getByRole("button", { name: /see how you scored/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId("player-results-breakdown")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/What is 2\+2\?/)).toBeInTheDocument();
+  });
+
+  it("hides the 'See how you scored' button once the breakdown is open", async () => {
+    render(<PodiumScreen entries={entries} playerResults={playerResults} />);
+    fireEvent.click(screen.getByRole("button", { name: /see how you scored/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /see how you scored/i })).not.toBeInTheDocument(),
+    );
   });
 
   // --- Mobile responsiveness ---


### PR DESCRIPTION
Closes #32

## Summary

- Breakdown is **hidden by default** — players see a gold "See how you scored" button instead
- Clicking the button reveals the full question-by-question breakdown with a fade-in animation
- Once open, the breakdown stays visible (no collapse needed per spec)
- No data-fetching changes — `playerResults` is still fetched eagerly

## Tests

- 3 new tests in `PodiumScreen.test.tsx`: breakdown hidden by default, revealed on click, button disappears after click
- Updated `PlayerGamePage.test.tsx` to click the toggle before asserting breakdown content

## How to test

1. Play a full game as a player through to the podium screen
2. Verify the question breakdown is NOT visible initially
3. Tap "See how you scored" — breakdown slides in
4. Confirm it stays open after reveal