### PR TITLE
feat(#68, #69): QR code in lobby + limit admin podium to top 3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.13.5",
     "lucide-react": "^0.575.0",
     "motion": "^12.34.3",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       motion:
         specifier: ^12.34.3
         version: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -1681,6 +1684,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -3451,6 +3459,10 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -156,7 +156,7 @@ export function HostGamePage() {
   }
 
   if (phase === "podium") {
-    return <PodiumScreen entries={podium} onEnd={handleEndGame} endLabel="Back to Dashboard" />;
+    return <PodiumScreen entries={podium.slice(0, 3)} onEnd={handleEndGame} endLabel="Back to Dashboard" />;
   }
 
   if (phase === "arc_transition") {

--- a/frontend/src/pages/HostLobbyPage.tsx
+++ b/frontend/src/pages/HostLobbyPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { motion } from "motion/react";
 import { Users, Copy, Check } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import { LanternIcon, CrescentIcon } from "../components/icons";
 import { getSessionByCode, listSessionPlayers, startSession } from "../api/sessions";
 import { useWebSocket } from "../hooks/useWebSocket";
@@ -152,6 +153,26 @@ export function HostLobbyPage() {
               style={{ background: copied ? "rgba(76,175,80,0.2)" : "rgba(245,200,66,0.2)", color: copied ? "#4caf50" : "#f5c842" }}>
               {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
             </motion.button>
+          </motion.div>
+
+          {/* QR code */}
+          <motion.div
+            className="flex justify-center"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: 0.25 }}
+          >
+            <div
+              className="p-4 rounded-2xl inline-block"
+              style={{ background: "white" }}
+            >
+              <QRCodeSVG
+                value={joinUrl}
+                size={200}
+                level="M"
+                data-testid="lobby-qr-code"
+              />
+            </div>
           </motion.div>
 
           {/* Player count */}

--- a/frontend/src/test/HostGamePage.test.tsx
+++ b/frontend/src/test/HostGamePage.test.tsx
@@ -187,4 +187,28 @@ describe("HostGamePage", () => {
     // Back to Dashboard is the only action button on the podium screen.
     expect(screen.getByRole("button", { name: /back to dashboard/i })).toBeInTheDocument();
   });
+
+  it("limits admin podium to top 3 players only", () => {
+    renderHostGame();
+    act(() =>
+      capturedOnMessage!({
+        type: "podium",
+        payload: {
+          entries: [
+            { player_id: "p1", name: "Alice", score: 3000, rank: 1 },
+            { player_id: "p2", name: "Bob", score: 2000, rank: 2 },
+            { player_id: "p3", name: "Carol", score: 1000, rank: 3 },
+            { player_id: "p4", name: "Dave", score: 500, rank: 4 },
+            { player_id: "p5", name: "Eve", score: 300, rank: 5 },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Carol")).toBeInTheDocument();
+    // 4th and 5th players should NOT appear on the admin podium
+    expect(screen.queryByText("Dave")).not.toBeInTheDocument();
+    expect(screen.queryByText("Eve")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/test/HostLobbyPage.test.tsx
+++ b/frontend/src/test/HostLobbyPage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { HostLobbyPage } from "../pages/HostLobbyPage";
+
+vi.mock("../api/sessions", () => ({
+  getSessionByCode: vi.fn().mockResolvedValue({ id: "s1", code: "ABC123", status: "waiting" }),
+  listSessionPlayers: vi.fn().mockResolvedValue([]),
+  startSession: vi.fn(),
+}));
+
+vi.mock("../hooks/useWebSocket", () => ({
+  useWebSocket: () => ({}),
+}));
+
+function renderLobby(code = "ABC123") {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/admin/lobby/${code}`]}>
+        <Routes>
+          <Route path="/admin/lobby/:code" element={<HostLobbyPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("HostLobbyPage", () => {
+  it("renders the room code", () => {
+    renderLobby();
+    expect(screen.getByText("ABC123")).toBeInTheDocument();
+  });
+
+  it("renders the join URL with the session code", () => {
+    renderLobby();
+    expect(screen.getByText(/\/join\?code=ABC123/)).toBeInTheDocument();
+  });
+
+  it("renders a QR code", () => {
+    renderLobby();
+    const qr = document.querySelector('[data-testid="lobby-qr-code"]');
+    expect(qr).toBeInTheDocument();
+  });
+
+  it("QR code is an SVG element", () => {
+    renderLobby();
+    const qr = document.querySelector('[data-testid="lobby-qr-code"]');
+    expect(qr?.tagName.toLowerCase()).toBe("svg");
+  });
+});


### PR DESCRIPTION
## Summary

- **#68 — QR code in lobby**: Added `qrcode.react` and rendered a QR code on the admin lobby/waiting screen that encodes the join URL. Players can scan it to navigate directly to the join page with the session code pre-filled. The existing join link is still displayed alongside the QR code.
- **#69 — Top 3 on admin podium**: Limited the admin game-over/podium screen to show only the top 3 players by slicing the entries passed to `PodiumScreen` from `HostGamePage`. The player view is unchanged and still shows all players.

Closes #68
Closes #69

## Changes

- `frontend/package.json` / `pnpm-lock.yaml` — added `qrcode.react` dependency
- `frontend/src/pages/HostLobbyPage.tsx` — import `QRCodeSVG`, render QR code between join URL and player list
- `frontend/src/pages/HostGamePage.tsx` — `podium.slice(0, 3)` passed to `PodiumScreen`
- `frontend/src/test/HostLobbyPage.test.tsx` — new test file (4 tests for QR code rendering)
- `frontend/src/test/HostGamePage.test.tsx` — added test verifying 4th+ players excluded from admin podium

## Test plan

- [ ] Open admin lobby — QR code visible below the join URL
- [ ] Scan QR code with phone — navigates to join page with code pre-filled
- [ ] QR code is large enough to scan from a reasonable distance
- [ ] Play a game with 4+ players — admin podium shows only top 3
- [ ] Player podium still shows all players and personal score
- [ ] All 112 tests pass (`./scripts/check.sh`)