### PR TITLE
feat(#25): validate required env vars on startup

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -24,6 +24,9 @@ func main() {
 	_ = godotenv.Load()
 
 	cfg := config.Load()
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("invalid configuration: %v", err)
+	}
 
 	database, err := db.Connect(cfg.DatabaseURL)
 	if err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strings"
+	"unicode"
 )
 
 type Config struct {
@@ -15,11 +18,6 @@ type Config struct {
 }
 
 func Load() *Config {
-	secret := getEnv("JWT_SECRET", "")
-	if secret == "" {
-		log.Fatal("JWT_SECRET environment variable is required")
-	}
-
 	anthropicKey := getEnv("ANTHROPIC_API_KEY", "")
 	if anthropicKey == "" {
 		log.Println("ANTHROPIC_API_KEY not set — AI quiz generation disabled")
@@ -29,10 +27,50 @@ func Load() *Config {
 		Port:            getEnv("PORT", "8081"),
 		DatabaseURL:     getEnv("DATABASE_URL", "postgres://hilal:hilal@localhost:5432/hilal?sslmode=disable"),
 		RedisURL:        getEnv("REDIS_URL", "redis://localhost:6379"),
-		JWTSecret:       secret,
+		JWTSecret:       getEnv("JWT_SECRET", ""),
 		FrontendURL:     getEnv("FRONTEND_URL", "http://localhost:5173"),
 		AnthropicAPIKey: anthropicKey,
 	}
+}
+
+// Validate checks that all required env vars are present and well-formed.
+// Call this before attempting any DB/Redis connections.
+func (c *Config) Validate() error {
+	required := map[string]string{
+		"DATABASE_URL": c.DatabaseURL,
+		"REDIS_URL":    c.RedisURL,
+		"JWT_SECRET":   c.JWTSecret,
+		"PORT":         c.Port,
+		"FRONTEND_URL": c.FrontendURL,
+	}
+	for name, val := range required {
+		if strings.TrimSpace(val) == "" {
+			return fmt.Errorf("%s is required and must not be empty", name)
+		}
+	}
+
+	if !strings.HasPrefix(c.DatabaseURL, "postgres://") && !strings.HasPrefix(c.DatabaseURL, "postgresql://") {
+		return fmt.Errorf("DATABASE_URL must start with postgres:// or postgresql://")
+	}
+
+	if !strings.HasPrefix(c.RedisURL, "redis://") && !strings.HasPrefix(c.RedisURL, "rediss://") {
+		return fmt.Errorf("REDIS_URL must start with redis:// or rediss://")
+	}
+	if containsControlChars(c.RedisURL) {
+		return fmt.Errorf("REDIS_URL contains control characters (newlines, tabs, etc.) — check for line-wrapping in your config")
+	}
+
+	return nil
+}
+
+// containsControlChars returns true if s contains any ASCII control character.
+func containsControlChars(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
 }
 
 func getEnv(key, defaultVal string) string {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,158 @@
+package config
+
+import "testing"
+
+func TestValidate_ValidConfig(t *testing.T) {
+	c := &Config{
+		Port:        "8081",
+		DatabaseURL: "postgres://user:pass@localhost:5432/db",
+		RedisURL:    "redis://localhost:6379",
+		JWTSecret:   "supersecret",
+		FrontendURL: "http://localhost:5173",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_PostgresqlPrefix(t *testing.T) {
+	c := &Config{
+		Port:        "8081",
+		DatabaseURL: "postgresql://user:pass@localhost:5432/db",
+		RedisURL:    "redis://localhost:6379",
+		JWTSecret:   "supersecret",
+		FrontendURL: "http://localhost:5173",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("expected no error for postgresql://, got: %v", err)
+	}
+}
+
+func TestValidate_RedissPrefix(t *testing.T) {
+	c := &Config{
+		Port:        "8081",
+		DatabaseURL: "postgres://user:pass@localhost:5432/db",
+		RedisURL:    "rediss://localhost:6379",
+		JWTSecret:   "supersecret",
+		FrontendURL: "http://localhost:5173",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("expected no error for rediss://, got: %v", err)
+	}
+}
+
+func TestValidate_MissingRequired(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name: "missing JWT_SECRET",
+			config: Config{
+				Port: "8081", DatabaseURL: "postgres://x", RedisURL: "redis://x", FrontendURL: "http://x",
+			},
+		},
+		{
+			name: "missing DATABASE_URL",
+			config: Config{
+				Port: "8081", RedisURL: "redis://x", JWTSecret: "x", FrontendURL: "http://x",
+			},
+		},
+		{
+			name: "missing REDIS_URL",
+			config: Config{
+				Port: "8081", DatabaseURL: "postgres://x", JWTSecret: "x", FrontendURL: "http://x",
+			},
+		},
+		{
+			name: "missing PORT",
+			config: Config{
+				DatabaseURL: "postgres://x", RedisURL: "redis://x", JWTSecret: "x", FrontendURL: "http://x",
+			},
+		},
+		{
+			name: "missing FRONTEND_URL",
+			config: Config{
+				Port: "8081", DatabaseURL: "postgres://x", RedisURL: "redis://x", JWTSecret: "x",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.config.Validate(); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidate_BadDatabaseURL(t *testing.T) {
+	c := &Config{
+		Port:        "8081",
+		DatabaseURL: "mysql://user:pass@localhost/db",
+		RedisURL:    "redis://localhost:6379",
+		JWTSecret:   "supersecret",
+		FrontendURL: "http://localhost:5173",
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for bad DATABASE_URL prefix")
+	}
+	if got := err.Error(); got != "DATABASE_URL must start with postgres:// or postgresql://" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestValidate_BadRedisURL(t *testing.T) {
+	c := &Config{
+		Port:        "8081",
+		DatabaseURL: "postgres://user:pass@localhost/db",
+		RedisURL:    "http://localhost:6379",
+		JWTSecret:   "supersecret",
+		FrontendURL: "http://localhost:5173",
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for bad REDIS_URL prefix")
+	}
+	if got := err.Error(); got != "REDIS_URL must start with redis:// or rediss://" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestValidate_RedisURLWithControlChars(t *testing.T) {
+	c := &Config{
+		Port:        "8081",
+		DatabaseURL: "postgres://user:pass@localhost/db",
+		RedisURL:    "redis://localhost:6379\n",
+		JWTSecret:   "supersecret",
+		FrontendURL: "http://localhost:5173",
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("expected error for REDIS_URL with control chars")
+	}
+	if got := err.Error(); got != "REDIS_URL contains control characters (newlines, tabs, etc.) — check for line-wrapping in your config" {
+		t.Errorf("unexpected error: %s", got)
+	}
+}
+
+func TestContainsControlChars(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"redis://localhost:6379", false},
+		{"redis://localhost:6379\n", true},
+		{"redis://localhost\t:6379", true},
+		{"redis://localhost\r:6379", true},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := containsControlChars(tc.input)
+		if got != tc.want {
+			t.Errorf("containsControlChars(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Config.Validate()` method that checks all required env vars are present and well-formed before any DB/Redis connections
- Validates `DATABASE_URL` prefix (`postgres://` or `postgresql://`)
- Validates `REDIS_URL` prefix (`redis://` or `rediss://`) and rejects control characters
- Called in `main.go` right after `config.Load()` — fails fast with a clear error message

Closes #25

## Test plan
- `config_test.go` covers: valid config, postgresql:// prefix, rediss:// prefix, each missing required var, bad DATABASE_URL prefix, bad REDIS_URL prefix, REDIS_URL with control chars, `containsControlChars` unit tests
- All checks pass via `./scripts/check.sh`