### PR TITLE
feat(#76): rate-limit AI quiz generation endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ FRONTEND_URL=http://localhost:5173
 # Get one at https://console.anthropic.com
 ANTHROPIC_API_KEY=
 
+# Max AI quiz generations per user per hour (default: 5)
+AI_RATE_LIMIT_PER_HOUR=5
+
 # ── Frontend (VITE_ prefix exposes to browser bundle) ─────────────────────
 # These are baked into the JS bundle at build time by Vite.
 # VITE_API_BASE_URL is unused (client.ts uses relative /api/v1 path).

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/HassanA01/Hilal/backend
 go 1.24.5
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -45,6 +47,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -4,17 +4,19 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"unicode"
 )
 
 type Config struct {
-	Port            string
-	DatabaseURL     string
-	RedisURL        string
-	JWTSecret       string
-	FrontendURL     string
-	AnthropicAPIKey string
+	Port               string
+	DatabaseURL        string
+	RedisURL           string
+	JWTSecret          string
+	FrontendURL        string
+	AnthropicAPIKey    string
+	AIRateLimitPerHour int
 }
 
 func Load() *Config {
@@ -23,13 +25,21 @@ func Load() *Config {
 		log.Println("ANTHROPIC_API_KEY not set — AI quiz generation disabled")
 	}
 
+	aiRateLimit := 5
+	if v := os.Getenv("AI_RATE_LIMIT_PER_HOUR"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			aiRateLimit = n
+		}
+	}
+
 	return &Config{
-		Port:            getEnv("PORT", "8081"),
-		DatabaseURL:     getEnv("DATABASE_URL", "postgres://hilal:hilal@localhost:5432/hilal?sslmode=disable"),
-		RedisURL:        getEnv("REDIS_URL", "redis://localhost:6379"),
-		JWTSecret:       getEnv("JWT_SECRET", ""),
-		FrontendURL:     getEnv("FRONTEND_URL", "http://localhost:5173"),
-		AnthropicAPIKey: anthropicKey,
+		Port:               getEnv("PORT", "8081"),
+		DatabaseURL:        getEnv("DATABASE_URL", "postgres://hilal:hilal@localhost:5432/hilal?sslmode=disable"),
+		RedisURL:           getEnv("REDIS_URL", "redis://localhost:6379"),
+		JWTSecret:          getEnv("JWT_SECRET", ""),
+		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:5173"),
+		AnthropicAPIKey:    anthropicKey,
+		AIRateLimitPerHour: aiRateLimit,
 	}
 }
 

--- a/backend/internal/handlers/ai.go
+++ b/backend/internal/handlers/ai.go
@@ -12,6 +12,9 @@ import (
 	"unicode"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/HassanA01/Hilal/backend/internal/middleware"
 )
 
 // maxAIQuestions is the hard cap on AI-generated question count.
@@ -60,26 +63,34 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. Check API key
+	// 3. Rate limit check
+	adminID := middleware.GetAdminID(r.Context())
+	if retryAfter, limited := h.checkRateLimit(r.Context(), adminID); limited {
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		writeError(w, http.StatusTooManyRequests, "Rate limit exceeded. You can generate up to "+strconv.Itoa(h.config.AIRateLimitPerHour)+" quizzes per hour.")
+		return
+	}
+
+	// 4. Check API key
 	if h.anthropicClient == nil {
 		writeError(w, http.StatusServiceUnavailable, "AI quiz generation is not configured")
 		return
 	}
 
-	// 4. Guardrail: classify input with Haiku before the expensive Sonnet call
+	// 5. Guardrail: classify input with Haiku before the expensive Sonnet call
 	if reason, ok := h.classifyInput(r.Context(), req.Topic, req.AdditionalContext); !ok {
 		slog.Warn("ai_generation_rejected", "reason", reason)
 		writeError(w, http.StatusBadRequest, reason)
 		return
 	}
 
-	// 5. Build prompt
+	// 6. Build prompt
 	userPrompt := "Generate a quiz about: " + req.Topic + ". Number of questions: " + strconv.Itoa(req.QuestionCount) + "."
 	if req.AdditionalContext != "" {
 		userPrompt += " Additional context: " + req.AdditionalContext
 	}
 
-	// 6. Define the tool schema
+	// 7. Define the tool schema
 	toolSchema := anthropic.ToolInputSchemaParam{
 		Properties: map[string]any{
 			"title": map[string]any{
@@ -134,7 +145,7 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 
 	tool := anthropic.ToolUnionParamOfTool(toolSchema, "create_quiz")
 
-	// 7. Call Claude with a 30s timeout, forced tool use
+	// 8. Call Claude with a 30s timeout, forced tool use
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
@@ -159,7 +170,7 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 8. Find the tool_use block in the response
+	// 9. Find the tool_use block in the response
 	var toolInput json.RawMessage
 	for _, block := range resp.Content {
 		if block.Type == "tool_use" && block.Name == "create_quiz" {
@@ -172,20 +183,20 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 9. Unmarshal into createQuizRequest (defined in quiz.go)
+	// 10. Unmarshal into createQuizRequest (defined in quiz.go)
 	var quiz createQuizRequest
 	if err := json.Unmarshal(toolInput, &quiz); err != nil {
 		writeError(w, http.StatusBadGateway, "AI returned malformed quiz data")
 		return
 	}
 
-	// 10. Validate result
+	// 11. Validate result
 	if quiz.Title == "" || len(quiz.Questions) == 0 {
 		writeError(w, http.StatusBadGateway, "AI returned an incomplete quiz")
 		return
 	}
 
-	// 11. Post-unmarshal validation: ensure each question has valid structure
+	// 12. Post-unmarshal validation: ensure each question has valid structure
 	for i, q := range quiz.Questions {
 		if q.Text == "" {
 			writeError(w, http.StatusBadGateway, "AI returned invalid response, please try again")
@@ -208,8 +219,67 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		_ = i
 	}
 
-	// 12. Return the generated quiz
+	// 13. Return the generated quiz
 	writeJSON(w, http.StatusOK, quiz)
+}
+
+// checkRateLimit uses a Redis sorted set as a sliding window to enforce
+// per-user rate limits on AI generation. Returns (retryAfterSeconds, true)
+// if the user has exceeded the limit.
+func (h *Handler) checkRateLimit(ctx context.Context, adminID string) (int, bool) {
+	if h.redis == nil {
+		return 0, false // no Redis → skip rate limiting
+	}
+
+	limit := h.config.AIRateLimitPerHour
+	if limit <= 0 {
+		return 0, false
+	}
+
+	key := "ratelimit:ai:" + adminID
+	now := time.Now()
+	windowStart := now.Add(-1 * time.Hour)
+
+	pipe := h.redis.Pipeline()
+
+	// Remove entries older than 1 hour
+	pipe.ZRemRangeByScore(ctx, key, "0", strconv.FormatInt(windowStart.UnixMilli(), 10))
+
+	// Count entries in the current window
+	countCmd := pipe.ZCard(ctx, key)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		slog.Warn("rate_limit_check_failed", "error", err)
+		return 0, false // fail-open
+	}
+
+	count := countCmd.Val()
+	if count >= int64(limit) {
+		// Find the oldest entry to calculate retry-after
+		oldest, err := h.redis.ZRangeWithScores(ctx, key, 0, 0).Result()
+		retryAfter := 60 // default fallback
+		if err == nil && len(oldest) > 0 {
+			oldestTime := time.UnixMilli(int64(oldest[0].Score))
+			retryAfter = int(oldestTime.Add(time.Hour).Sub(now).Seconds()) + 1
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
+		}
+		return retryAfter, true
+	}
+
+	// Add the current request to the window
+	if err := h.redis.ZAdd(ctx, key, redis.Z{
+		Score:  float64(now.UnixMilli()),
+		Member: strconv.FormatInt(now.UnixNano(), 10),
+	}).Err(); err != nil {
+		slog.Warn("rate_limit_record_failed", "error", err)
+	}
+
+	// Set TTL so the key auto-expires
+	h.redis.Expire(ctx, key, time.Hour+time.Minute)
+
+	return 0, false
 }
 
 const classifySystemPrompt = `You are a content classifier for an educational quiz generation app.

--- a/backend/internal/handlers/ai_test.go
+++ b/backend/internal/handlers/ai_test.go
@@ -1,11 +1,19 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/HassanA01/Hilal/backend/internal/config"
+	"github.com/HassanA01/Hilal/backend/internal/middleware"
 )
 
 func TestGenerateQuiz_MissingAPIKey(t *testing.T) {
@@ -152,5 +160,129 @@ func TestClassifyInput_FailOpen_NilClient(t *testing.T) {
 	}
 	if reason != "" {
 		t.Errorf("expected empty reason on fail-open, got: %s", reason)
+	}
+}
+
+// newTestHandlerWithRedis creates a handler backed by miniredis for rate limit testing.
+func newTestHandlerWithRedis(t *testing.T, limit int) (*Handler, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { rc.Close() })
+	return &Handler{
+		redis: rc,
+		config: &config.Config{
+			JWTSecret:          "test-secret-that-is-long-enough",
+			AIRateLimitPerHour: limit,
+		},
+	}, mr
+}
+
+func TestCheckRateLimit_NilRedis(t *testing.T) {
+	h := newTestHandler() // redis is nil
+	retryAfter, limited := h.checkRateLimit(context.Background(), "admin-1")
+	if limited {
+		t.Error("expected no rate limiting with nil redis")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0, got %d", retryAfter)
+	}
+}
+
+func TestCheckRateLimit_ZeroLimit(t *testing.T) {
+	h, _ := newTestHandlerWithRedis(t, 0)
+	_, limited := h.checkRateLimit(context.Background(), "admin-1")
+	if limited {
+		t.Error("expected no rate limiting with limit=0")
+	}
+}
+
+func TestCheckRateLimit_UnderLimit(t *testing.T) {
+	h, _ := newTestHandlerWithRedis(t, 5)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_, limited := h.checkRateLimit(ctx, "admin-1")
+		if limited {
+			t.Fatalf("request %d should not be rate limited", i+1)
+		}
+	}
+}
+
+func TestCheckRateLimit_ExceedsLimit(t *testing.T) {
+	h, _ := newTestHandlerWithRedis(t, 3)
+	ctx := context.Background()
+
+	// Make 3 requests (at the limit)
+	for i := 0; i < 3; i++ {
+		_, limited := h.checkRateLimit(ctx, "admin-1")
+		if limited {
+			t.Fatalf("request %d should not be rate limited", i+1)
+		}
+	}
+
+	// 4th request should be rate limited
+	retryAfter, limited := h.checkRateLimit(ctx, "admin-1")
+	if !limited {
+		t.Error("4th request should be rate limited")
+	}
+	if retryAfter <= 0 {
+		t.Errorf("expected positive retryAfter, got %d", retryAfter)
+	}
+}
+
+func TestCheckRateLimit_PerUser(t *testing.T) {
+	h, _ := newTestHandlerWithRedis(t, 2)
+	ctx := context.Background()
+
+	// admin-1 makes 2 requests
+	for i := 0; i < 2; i++ {
+		_, limited := h.checkRateLimit(ctx, "admin-1")
+		if limited {
+			t.Fatalf("admin-1 request %d should not be limited", i+1)
+		}
+	}
+
+	// admin-1 is now limited
+	_, limited := h.checkRateLimit(ctx, "admin-1")
+	if !limited {
+		t.Error("admin-1 should be limited after 2 requests")
+	}
+
+	// admin-2 should still be allowed
+	_, limited = h.checkRateLimit(ctx, "admin-2")
+	if limited {
+		t.Error("admin-2 should not be limited")
+	}
+}
+
+func TestGenerateQuiz_RateLimited(t *testing.T) {
+	h, _ := newTestHandlerWithRedis(t, 1)
+
+	makeRequest := func() *httptest.ResponseRecorder {
+		body, _ := json.Marshal(map[string]any{
+			"topic":          "Science",
+			"question_count": 3,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = req.WithContext(middleware.ContextWithAdminID(req.Context(), "admin-1"))
+		w := httptest.NewRecorder()
+		h.GenerateQuiz(w, req)
+		return w
+	}
+
+	// First request should pass validation and hit 503 (no anthropic client)
+	w := makeRequest()
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("first request: want 503, got %d", w.Code)
+	}
+
+	// Second request should be rate limited
+	w = makeRequest()
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("second request: want 429, got %d", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header")
 	}
 }

--- a/frontend/src/components/GenerateQuizModal.tsx
+++ b/frontend/src/components/GenerateQuizModal.tsx
@@ -35,9 +35,13 @@ export function GenerateQuizModal({ onClose, onGenerated }: Props) {
       const data = await generateQuiz({ topic: topic.trim(), question_count: count, context: context.trim() });
       onGenerated(data);
     } catch (err: unknown) {
-      const msg =
-        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
-        "Something went wrong. Please try again.";
+      const axiosErr = err as { response?: { status?: number; data?: { error?: string } } };
+      let msg: string;
+      if (axiosErr?.response?.status === 429) {
+        msg = axiosErr.response.data?.error ?? "Rate limit exceeded. Please try again later.";
+      } else {
+        msg = axiosErr?.response?.data?.error ?? "Something went wrong. Please try again.";
+      }
       setError(msg);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- Adds per-user rate limiting to `/api/v1/quizzes/generate` using a Redis sliding window (sorted set)
- Default: 5 requests per hour per user, configurable via `AI_RATE_LIMIT_PER_HOUR` env var
- Returns `429 Too Many Requests` with `Retry-After` header when exceeded
- Frontend displays the rate limit error message from the backend
- Fail-open: if Redis is unavailable, requests proceed without rate limiting

Closes #76

## Test plan
- [ ] `TestCheckRateLimit_NilRedis` — skips rate limiting when Redis is nil
- [ ] `TestCheckRateLimit_ZeroLimit` — skips rate limiting when limit is 0
- [ ] `TestCheckRateLimit_UnderLimit` — allows requests under the limit
- [ ] `TestCheckRateLimit_ExceedsLimit` — blocks requests over the limit with positive Retry-After
- [ ] `TestCheckRateLimit_PerUser` — rate limits are per-user, not global
- [ ] `TestGenerateQuiz_RateLimited` — full handler test: first request passes, second returns 429