### PR TITLE
feat(#99): AI quiz generation from uploaded documents

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 // indirect
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -31,6 +31,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=

--- a/backend/internal/docextract/extract.go
+++ b/backend/internal/docextract/extract.go
@@ -1,0 +1,202 @@
+package docextract
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/ledongthuc/pdf"
+)
+
+// MaxDocumentSize is the maximum upload size (5MB).
+const MaxDocumentSize = 5 << 20
+
+// MaxTextLength is the truncation limit for extracted text.
+const MaxTextLength = 50_000
+
+// SupportedExtensions lists allowed file extensions.
+var SupportedExtensions = map[string]bool{
+	".pdf":  true,
+	".docx": true,
+	".txt":  true,
+	".md":   true,
+}
+
+// Result holds the extracted text and whether it was truncated.
+type Result struct {
+	Text      string
+	Truncated bool
+}
+
+// Extract reads file content and returns plain text.
+// The filename is used to determine format by extension.
+func Extract(data []byte, filename string) (Result, error) {
+	if len(data) == 0 {
+		return Result{}, fmt.Errorf("file is empty")
+	}
+
+	ext := strings.ToLower(filepath.Ext(filename))
+	if !SupportedExtensions[ext] {
+		return Result{}, fmt.Errorf("unsupported file type %q: supported formats are PDF, DOCX, TXT, MD", ext)
+	}
+
+	if err := validateMagicBytes(data, ext); err != nil {
+		return Result{}, err
+	}
+
+	var text string
+	var err error
+
+	switch ext {
+	case ".pdf":
+		text, err = extractPDF(data)
+	case ".docx":
+		text, err = extractDOCX(data)
+	case ".txt", ".md":
+		text, err = extractPlaintext(data)
+	}
+	if err != nil {
+		return Result{}, err
+	}
+
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return Result{}, fmt.Errorf("no readable text found in document")
+	}
+
+	truncated := false
+	if len(text) > MaxTextLength {
+		text = truncateAtWordBoundary(text, MaxTextLength)
+		truncated = true
+	}
+
+	return Result{Text: text, Truncated: truncated}, nil
+}
+
+func extractPDF(data []byte) (string, error) {
+	reader, err := pdf.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse PDF: %w", err)
+	}
+
+	var buf strings.Builder
+	for i := 1; i <= reader.NumPage(); i++ {
+		page := reader.Page(i)
+		if page.V.IsNull() {
+			continue
+		}
+		text, err := page.GetPlainText(nil)
+		if err != nil {
+			continue
+		}
+		buf.WriteString(text)
+		buf.WriteString("\n")
+	}
+	return buf.String(), nil
+}
+
+func extractDOCX(data []byte) (string, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("failed to open DOCX: %w", err)
+	}
+
+	for _, f := range zr.File {
+		if f.Name != "word/document.xml" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("failed to read document.xml: %w", err)
+		}
+		defer rc.Close()
+		return parseDocXML(rc)
+	}
+	return "", fmt.Errorf("word/document.xml not found in DOCX")
+}
+
+// parseDocXML extracts text from the Word document XML by collecting <w:t> elements.
+func parseDocXML(r io.Reader) (string, error) {
+	decoder := xml.NewDecoder(r)
+	var buf strings.Builder
+	inText := false
+	lastWasParagraph := false
+
+	for {
+		tok, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to parse document XML: %w", err)
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "t" {
+				inText = true
+			}
+			if t.Name.Local == "p" && buf.Len() > 0 && !lastWasParagraph {
+				buf.WriteString("\n")
+				lastWasParagraph = true
+			}
+		case xml.EndElement:
+			if t.Name.Local == "t" {
+				inText = false
+			}
+		case xml.CharData:
+			if inText {
+				buf.Write(t)
+				lastWasParagraph = false
+			}
+		}
+	}
+	return buf.String(), nil
+}
+
+func extractPlaintext(data []byte) (string, error) {
+	if !utf8.Valid(data) {
+		return "", fmt.Errorf("file is not valid UTF-8 text")
+	}
+	return string(data), nil
+}
+
+func validateMagicBytes(data []byte, ext string) error {
+	switch ext {
+	case ".pdf":
+		if len(data) < 4 || string(data[:4]) != "%PDF" {
+			return fmt.Errorf("file does not appear to be a valid PDF")
+		}
+	case ".docx":
+		if len(data) < 4 || data[0] != 'P' || data[1] != 'K' || data[2] != 0x03 || data[3] != 0x04 {
+			return fmt.Errorf("file does not appear to be a valid DOCX")
+		}
+	case ".txt", ".md":
+		// Check first 512 bytes are valid UTF-8.
+		sample := data
+		if len(sample) > 512 {
+			sample = sample[:512]
+		}
+		if !utf8.Valid(sample) {
+			return fmt.Errorf("file does not appear to be valid text")
+		}
+	}
+	return nil
+}
+
+func truncateAtWordBoundary(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	truncated := s[:maxLen]
+	// Find the last space to avoid cutting a word in half.
+	if idx := strings.LastIndex(truncated, " "); idx > maxLen/2 {
+		truncated = truncated[:idx]
+	}
+	return truncated
+}

--- a/backend/internal/docextract/extract_test.go
+++ b/backend/internal/docextract/extract_test.go
@@ -1,0 +1,182 @@
+package docextract
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestExtract_Plaintext(t *testing.T) {
+	content := "Hello, this is a test document with some content."
+	result, err := Extract([]byte(content), "notes.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != content {
+		t.Errorf("expected %q, got %q", content, result.Text)
+	}
+	if result.Truncated {
+		t.Error("expected Truncated=false")
+	}
+}
+
+func TestExtract_Markdown(t *testing.T) {
+	content := "# Heading\n\nSome paragraph text."
+	result, err := Extract([]byte(content), "readme.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != content {
+		t.Errorf("expected %q, got %q", content, result.Text)
+	}
+}
+
+func TestExtract_EmptyFile(t *testing.T) {
+	_, err := Extract([]byte{}, "empty.txt")
+	if err == nil {
+		t.Fatal("expected error for empty file")
+	}
+}
+
+func TestExtract_NoReadableText(t *testing.T) {
+	_, err := Extract([]byte("   \n\t  \n  "), "whitespace.txt")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only file")
+	}
+}
+
+func TestExtract_InvalidUTF8(t *testing.T) {
+	data := []byte{0xff, 0xfe, 0x00, 0x01} // invalid UTF-8
+	_, err := Extract(data, "binary.txt")
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8")
+	}
+}
+
+func TestExtract_UnsupportedExtension(t *testing.T) {
+	_, err := Extract([]byte("data"), "sheet.xlsx")
+	if err == nil {
+		t.Fatal("expected error for unsupported extension")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("expected 'unsupported' in error, got %q", err.Error())
+	}
+}
+
+func TestExtract_DOCX(t *testing.T) {
+	docx := makeMinimalDOCX("This is the document body text.")
+	result, err := Extract(docx, "test.docx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Text, "This is the document body text.") {
+		t.Errorf("expected extracted text to contain document body, got %q", result.Text)
+	}
+}
+
+func TestExtract_DOCX_MultipleParagraphs(t *testing.T) {
+	docx := makeMultiParagraphDOCX([]string{"First paragraph.", "Second paragraph."})
+	result, err := Extract(docx, "multi.docx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Text, "First paragraph.") || !strings.Contains(result.Text, "Second paragraph.") {
+		t.Errorf("expected both paragraphs, got %q", result.Text)
+	}
+}
+
+func TestExtract_DOCX_BadMagicBytes(t *testing.T) {
+	_, err := Extract([]byte("not a zip file"), "fake.docx")
+	if err == nil {
+		t.Fatal("expected error for invalid DOCX magic bytes")
+	}
+}
+
+func TestValidateMagicBytes_PDF(t *testing.T) {
+	if err := validateMagicBytes([]byte("%PDF-1.4 content"), ".pdf"); err != nil {
+		t.Errorf("expected valid PDF magic bytes, got error: %v", err)
+	}
+	if err := validateMagicBytes([]byte("not a pdf"), ".pdf"); err == nil {
+		t.Error("expected error for invalid PDF magic bytes")
+	}
+}
+
+func TestValidateMagicBytes_DOCX(t *testing.T) {
+	data := []byte{'P', 'K', 0x03, 0x04, 0x00}
+	if err := validateMagicBytes(data, ".docx"); err != nil {
+		t.Errorf("expected valid DOCX magic bytes, got error: %v", err)
+	}
+	if err := validateMagicBytes([]byte("not a zip"), ".docx"); err == nil {
+		t.Error("expected error for invalid DOCX magic bytes")
+	}
+}
+
+func TestTruncateAtWordBoundary(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short string", "hello world", 100, "hello world"},
+		{"exact boundary", "hello world", 5, "hello"},
+		{"mid-word", "hello beautiful world", 12, "hello beauti"}, // space at idx 5 < maxLen/2, so no word-boundary cut
+		{"long text", "word1 word2 word3 word4", 11, "word1 word2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateAtWordBoundary(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateAtWordBoundary(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtract_Truncation(t *testing.T) {
+	// Build a string longer than MaxTextLength.
+	word := "test "
+	count := (MaxTextLength / len(word)) + 100
+	long := strings.Repeat(word, count)
+
+	result, err := Extract([]byte(long), "long.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Truncated {
+		t.Error("expected Truncated=true for long text")
+	}
+	if len(result.Text) > MaxTextLength {
+		t.Errorf("expected text length <= %d, got %d", MaxTextLength, len(result.Text))
+	}
+}
+
+// makeMinimalDOCX creates a minimal valid DOCX (ZIP) with a single paragraph.
+func makeMinimalDOCX(text string) []byte {
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	f, _ := w.Create("word/document.xml")
+	fmt.Fprintf(f,
+		`<?xml version="1.0" encoding="UTF-8"?>`+
+			`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">`+
+			`<w:body><w:p><w:r><w:t>%s</w:t></w:r></w:p></w:body></w:document>`, text)
+	w.Close()
+	return buf.Bytes()
+}
+
+// makeMultiParagraphDOCX creates a DOCX with multiple paragraphs.
+func makeMultiParagraphDOCX(paragraphs []string) []byte {
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	f, _ := w.Create("word/document.xml")
+	fmt.Fprintf(f, `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`)
+	for _, p := range paragraphs {
+		fmt.Fprintf(f, `<w:p><w:r><w:t>%s</w:t></w:r></w:p>`, p)
+	}
+	fmt.Fprintf(f, `</w:body></w:document>`)
+	w.Close()
+	return buf.Bytes()
+}

--- a/backend/internal/handlers/ai.go
+++ b/backend/internal/handlers/ai.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +16,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/redis/go-redis/v9"
 
+	"github.com/HassanA01/Hilal/backend/internal/docextract"
 	"github.com/HassanA01/Hilal/backend/internal/metrics"
 	"github.com/HassanA01/Hilal/backend/internal/middleware"
 )
@@ -78,20 +81,116 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 5. Guardrail: classify input with Haiku before the expensive Sonnet call
-	if reason, ok := h.classifyInput(r.Context(), req.Topic, req.AdditionalContext); !ok {
-		slog.Warn("ai_generation_rejected", "reason", reason)
-		writeError(w, http.StatusBadRequest, reason)
-		return
+	// 5. Build guardrail text and prompt
+	guardrailText := req.Topic
+	if req.AdditionalContext != "" {
+		guardrailText += "\n" + req.AdditionalContext
 	}
-
-	// 6. Build prompt
 	userPrompt := "Generate a quiz about: " + req.Topic + ". Number of questions: " + strconv.Itoa(req.QuestionCount) + "."
 	if req.AdditionalContext != "" {
 		userPrompt += " Additional context: " + req.AdditionalContext
 	}
 
-	// 7. Define the tool schema
+	// 6. Delegate to shared pipeline (guardrail → Claude call → parse → validate → respond)
+	h.generateQuizFromText(w, r, guardrailText, userPrompt)
+}
+
+const maxUploadSize = docextract.MaxDocumentSize
+
+// GenerateQuizFromUpload generates a quiz from an uploaded document.
+func (h *Handler) GenerateQuizFromUpload(w http.ResponseWriter, r *http.Request) {
+	// 1. Parse multipart form
+	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
+		writeError(w, http.StatusBadRequest, "file too large (max 5MB)")
+		return
+	}
+
+	// 2. Get question_count from form field
+	questionCount, err := strconv.Atoi(r.FormValue("question_count"))
+	if err != nil || questionCount < 1 || questionCount > maxAIQuestions {
+		writeError(w, http.StatusBadRequest, "question_count must be between 1 and "+strconv.Itoa(maxAIQuestions))
+		return
+	}
+
+	// 3. Get the file
+	file, header, err := r.FormFile("document")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "document file is required")
+		return
+	}
+	defer file.Close()
+
+	// 4. Validate file size
+	if header.Size > maxUploadSize {
+		writeError(w, http.StatusBadRequest, "file too large (max 5MB)")
+		return
+	}
+
+	// 5. Validate extension
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	if !docextract.SupportedExtensions[ext] {
+		writeError(w, http.StatusBadRequest, "unsupported file type: supported formats are PDF, DOCX, TXT, MD")
+		return
+	}
+
+	// 6. Read file into memory
+	data, err := io.ReadAll(io.LimitReader(file, maxUploadSize+1))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read file")
+		return
+	}
+	if int64(len(data)) > maxUploadSize {
+		writeError(w, http.StatusBadRequest, "file too large (max 5MB)")
+		return
+	}
+
+	// 7. Extract text (before rate limit so invalid files don't consume quota)
+	result, err := docextract.Extract(data, header.Filename)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to extract text: "+err.Error())
+		return
+	}
+
+	// 8. Rate limit check
+	adminID := middleware.GetAdminID(r.Context())
+	if retryAfter, limited := h.checkRateLimit(r.Context(), adminID); limited {
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		writeError(w, http.StatusTooManyRequests, "Rate limit exceeded. You can generate up to "+strconv.Itoa(h.config.AIRateLimitPerHour)+" quizzes per hour.")
+		return
+	}
+
+	// 9. Check API key
+	if h.anthropicClient == nil {
+		writeError(w, http.StatusServiceUnavailable, "AI quiz generation is not configured")
+		return
+	}
+
+	// 10. Build guardrail snippet (first 1000 chars) and prompt
+	guardrailSnippet := result.Text
+	if len(guardrailSnippet) > 1000 {
+		guardrailSnippet = guardrailSnippet[:1000]
+	}
+
+	userPrompt := fmt.Sprintf(
+		"Generate a quiz with %d questions based on the following document content. "+
+			"Extract the key concepts and create questions that test understanding of the material.\n\n"+
+			"Document content:\n%s", questionCount, result.Text)
+
+	// 11. Delegate to shared pipeline
+	h.generateQuizFromText(w, r, guardrailSnippet, userPrompt)
+}
+
+// generateQuizFromText runs the shared AI quiz generation pipeline:
+// guardrail classification → Claude Sonnet call → parse tool response → validate → respond.
+func (h *Handler) generateQuizFromText(w http.ResponseWriter, r *http.Request, guardrailText, userPrompt string) {
+	// 1. Guardrail: classify input with Haiku before the expensive Sonnet call
+	if reason, ok := h.classifyInput(r.Context(), guardrailText, ""); !ok {
+		slog.Warn("ai_generation_rejected", "reason", reason)
+		writeError(w, http.StatusBadRequest, reason)
+		return
+	}
+
+	// 2. Define the tool schema
 	toolSchema := anthropic.ToolInputSchemaParam{
 		Properties: map[string]any{
 			"title": map[string]any{
@@ -146,7 +245,7 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 
 	tool := anthropic.ToolUnionParamOfTool(toolSchema, "create_quiz")
 
-	// 8. Call Claude with a 30s timeout, forced tool use
+	// 3. Call Claude with a 30s timeout, forced tool use
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
@@ -173,7 +272,7 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 9. Find the tool_use block in the response
+	// 4. Find the tool_use block in the response
 	var toolInput json.RawMessage
 	for _, block := range resp.Content {
 		if block.Type == "tool_use" && block.Name == "create_quiz" {
@@ -186,20 +285,20 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 10. Unmarshal into createQuizRequest (defined in quiz.go)
+	// 5. Unmarshal into createQuizRequest (defined in quiz.go)
 	var quiz createQuizRequest
 	if err := json.Unmarshal(toolInput, &quiz); err != nil {
 		writeError(w, http.StatusBadGateway, "AI returned malformed quiz data")
 		return
 	}
 
-	// 11. Validate result
+	// 6. Validate result
 	if quiz.Title == "" || len(quiz.Questions) == 0 {
 		writeError(w, http.StatusBadGateway, "AI returned an incomplete quiz")
 		return
 	}
 
-	// 12. Post-unmarshal validation: ensure each question has valid structure
+	// 7. Post-unmarshal validation: ensure each question has valid structure
 	for i, q := range quiz.Questions {
 		if q.Text == "" {
 			writeError(w, http.StatusBadGateway, "AI returned invalid response, please try again")
@@ -222,7 +321,7 @@ func (h *Handler) GenerateQuiz(w http.ResponseWriter, r *http.Request) {
 		_ = i
 	}
 
-	// 13. Return the generated quiz
+	// 8. Return the generated quiz
 	writeJSON(w, http.StatusOK, quiz)
 }
 

--- a/backend/internal/handlers/ai_test.go
+++ b/backend/internal/handlers/ai_test.go
@@ -1,9 +1,12 @@
 package handlers
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -285,4 +288,165 @@ func TestGenerateQuiz_RateLimited(t *testing.T) {
 	if w.Header().Get("Retry-After") == "" {
 		t.Error("expected Retry-After header")
 	}
+}
+
+// --- Upload handler tests ---
+
+// postMultipart builds a multipart request with a file and optional form fields.
+func postMultipart(t *testing.T, handler http.HandlerFunc, filename string, fileContent []byte, fields map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if fileContent != nil {
+		part, err := writer.CreateFormFile("document", filename)
+		if err != nil {
+			t.Fatalf("create form file: %v", err)
+		}
+		if _, err := part.Write(fileContent); err != nil {
+			t.Fatalf("write file content: %v", err)
+		}
+	}
+	for k, v := range fields {
+		if err := writer.WriteField(k, v); err != nil {
+			t.Fatalf("write field %s: %v", k, err)
+		}
+	}
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+	handler(w, req)
+	return w
+}
+
+func TestGenerateQuizFromUpload_MissingFile(t *testing.T) {
+	h := newTestHandler()
+	w := postMultipart(t, h.GenerateQuizFromUpload, "", nil, map[string]string{
+		"question_count": "5",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", w.Code)
+	}
+}
+
+func TestGenerateQuizFromUpload_UnsupportedExtension(t *testing.T) {
+	h := newTestHandler()
+	w := postMultipart(t, h.GenerateQuizFromUpload, "sheet.xlsx", []byte("data"), map[string]string{
+		"question_count": "5",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", w.Code)
+	}
+}
+
+func TestGenerateQuizFromUpload_InvalidQuestionCount(t *testing.T) {
+	h := newTestHandler()
+
+	tests := []struct {
+		name  string
+		count string
+	}{
+		{"zero", "0"},
+		{"eleven", "11"},
+		{"non-numeric", "abc"},
+		{"empty", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := postMultipart(t, h.GenerateQuizFromUpload, "notes.txt", []byte("some content"), map[string]string{
+				"question_count": tc.count,
+			})
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("want 400, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestGenerateQuizFromUpload_EmptyTextFile(t *testing.T) {
+	h := newTestHandler()
+	w := postMultipart(t, h.GenerateQuizFromUpload, "empty.txt", []byte("   \n  "), map[string]string{
+		"question_count": "5",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", w.Code)
+	}
+}
+
+func TestGenerateQuizFromUpload_MissingAPIKey(t *testing.T) {
+	h := newTestHandler()
+	w := postMultipart(t, h.GenerateQuizFromUpload, "notes.txt", []byte("This is a document about science and biology."), map[string]string{
+		"question_count": "5",
+	})
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503 (passed validation), got %d", w.Code)
+	}
+}
+
+func TestGenerateQuizFromUpload_ValidDocx(t *testing.T) {
+	h := newTestHandler()
+	docx := makeTestDOCX("This is document body text about history.")
+	w := postMultipart(t, h.GenerateQuizFromUpload, "lesson.docx", docx, map[string]string{
+		"question_count": "3",
+	})
+	// Should pass validation and reach the 503 (no anthropic client)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503 (passed validation), got %d", w.Code)
+	}
+}
+
+func TestGenerateQuizFromUpload_BadMagicBytes(t *testing.T) {
+	h := newTestHandler()
+	w := postMultipart(t, h.GenerateQuizFromUpload, "fake.pdf", []byte("not a pdf file"), map[string]string{
+		"question_count": "5",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", w.Code)
+	}
+}
+
+func TestGenerateQuizFromUpload_RateLimited(t *testing.T) {
+	h, _ := newTestHandlerWithRedis(t, 1)
+
+	makeRequest := func() *httptest.ResponseRecorder {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		part, _ := writer.CreateFormFile("document", "notes.txt")
+		_, _ = part.Write([]byte("Some document content for quiz generation."))
+		_ = writer.WriteField("question_count", "3")
+		writer.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/", &buf)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		req = req.WithContext(middleware.ContextWithAdminID(req.Context(), "admin-1"))
+		w := httptest.NewRecorder()
+		h.GenerateQuizFromUpload(w, req)
+		return w
+	}
+
+	// First request: passes rate limit, hits 503 (no anthropic client)
+	w := makeRequest()
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("first request: want 503, got %d", w.Code)
+	}
+
+	// Second request: rate limited
+	w = makeRequest()
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("second request: want 429, got %d", w.Code)
+	}
+}
+
+// makeTestDOCX creates a minimal valid DOCX (ZIP) with a single paragraph.
+func makeTestDOCX(text string) []byte {
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	f, _ := w.Create("word/document.xml")
+	fmt.Fprintf(f,
+		`<?xml version="1.0" encoding="UTF-8"?>`+
+			`<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">`+
+			`<w:body><w:p><w:r><w:t>%s</w:t></w:r></w:p></w:body></w:document>`, text)
+	w.Close()
+	return buf.Bytes()
 }

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -49,6 +49,7 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 			r.Get("/quizzes", h.ListQuizzes)
 			r.Post("/quizzes", h.CreateQuiz)
 			r.Post("/quizzes/generate", h.GenerateQuiz)
+			r.Post("/quizzes/generate/upload", h.GenerateQuizFromUpload)
 			r.Get("/quizzes/{quizID}", h.GetQuiz)
 			r.Put("/quizzes/{quizID}", h.UpdateQuiz)
 			r.Delete("/quizzes/{quizID}", h.DeleteQuiz)

--- a/frontend/src/api/ai.ts
+++ b/frontend/src/api/ai.ts
@@ -16,3 +16,22 @@ export async function generateQuiz(input: GenerateQuizInput): Promise<GenerateQu
   const { data } = await apiClient.post<GenerateQuizResponse>("/quizzes/generate", input);
   return data;
 }
+
+export async function generateQuizFromUpload(
+  file: File,
+  questionCount: number,
+): Promise<GenerateQuizResponse> {
+  const formData = new FormData();
+  formData.append("document", file);
+  formData.append("question_count", String(questionCount));
+
+  const { data } = await apiClient.post<GenerateQuizResponse>(
+    "/quizzes/generate/upload",
+    formData,
+    {
+      headers: { "Content-Type": "multipart/form-data" },
+      timeout: 60000,
+    },
+  );
+  return data;
+}

--- a/frontend/src/components/GenerateQuizModal.tsx
+++ b/frontend/src/components/GenerateQuizModal.tsx
@@ -1,19 +1,33 @@
-import { useState, type FormEvent } from "react";
+import { useState, useRef, type FormEvent } from "react";
 import { motion } from "motion/react";
-import { Sparkles, X } from "lucide-react";
-import { generateQuiz, type GenerateQuizResponse } from "../api/ai";
+import { Sparkles, X, Upload, FileText, Trash2 } from "lucide-react";
+import { generateQuiz, generateQuizFromUpload, type GenerateQuizResponse } from "../api/ai";
 
 interface Props {
   onClose: () => void;
   onGenerated: (data: GenerateQuizResponse) => void;
 }
 
+const ACCEPTED_EXTENSIONS = [".pdf", ".docx", ".txt", ".md"];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+  return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+}
+
 export function GenerateQuizModal({ onClose, onGenerated }: Props) {
+  const [mode, setMode] = useState<"topic" | "upload">("topic");
   const [topic, setTopic] = useState("");
   const [count, setCount] = useState(5);
   const [context, setContext] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [loadingStep, setLoadingStep] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const inputStyle = {
     background: "rgba(255,255,255,0.06)",
@@ -23,7 +37,55 @@ export function GenerateQuizModal({ onClose, onGenerated }: Props) {
 
   const countInvalid = count < 1 || count > 10;
 
-  async function handleSubmit(e: FormEvent) {
+  function validateFile(selected: File): boolean {
+    setFileError(null);
+    const ext = "." + selected.name.split(".").pop()?.toLowerCase();
+    if (!ACCEPTED_EXTENSIONS.includes(ext)) {
+      setFileError("Unsupported file type. Use PDF, DOCX, TXT, or MD.");
+      return false;
+    }
+    if (selected.size > MAX_FILE_SIZE) {
+      setFileError("File too large. Maximum size is 5MB.");
+      return false;
+    }
+    return true;
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+    if (validateFile(selected)) {
+      setFile(selected);
+      setError(null);
+    } else {
+      setFile(null);
+    }
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    const dropped = e.dataTransfer.files[0];
+    if (!dropped) return;
+    if (validateFile(dropped)) {
+      setFile(dropped);
+      setError(null);
+    } else {
+      setFile(null);
+    }
+  }
+
+  function handleError(err: unknown) {
+    const axiosErr = err as { response?: { status?: number; data?: { error?: string } } };
+    let msg: string;
+    if (axiosErr?.response?.status === 429) {
+      msg = axiosErr.response.data?.error ?? "Rate limit exceeded. Please try again later.";
+    } else {
+      msg = axiosErr?.response?.data?.error ?? "Something went wrong. Please try again.";
+    }
+    setError(msg);
+  }
+
+  async function handleTopicSubmit(e: FormEvent) {
     e.preventDefault();
     if (countInvalid) {
       setError("Maximum 10 questions for AI generation.");
@@ -31,22 +93,45 @@ export function GenerateQuizModal({ onClose, onGenerated }: Props) {
     }
     setError(null);
     setLoading(true);
+    setLoadingStep("Summoning questions from the stars...");
     try {
       const data = await generateQuiz({ topic: topic.trim(), question_count: count, context: context.trim() });
       onGenerated(data);
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { status?: number; data?: { error?: string } } };
-      let msg: string;
-      if (axiosErr?.response?.status === 429) {
-        msg = axiosErr.response.data?.error ?? "Rate limit exceeded. Please try again later.";
-      } else {
-        msg = axiosErr?.response?.data?.error ?? "Something went wrong. Please try again.";
-      }
-      setError(msg);
+      handleError(err);
     } finally {
       setLoading(false);
+      setLoadingStep("");
     }
   }
+
+  async function handleUploadSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!file) { setError("Please select a file."); return; }
+    if (countInvalid) { setError("Maximum 10 questions for AI generation."); return; }
+    setError(null);
+    setLoading(true);
+    setLoadingStep("Extracting text from document...");
+
+    const timer = setTimeout(() => setLoadingStep("Generating questions..."), 3000);
+
+    try {
+      const data = await generateQuizFromUpload(file, count);
+      onGenerated(data);
+    } catch (err: unknown) {
+      handleError(err);
+    } finally {
+      clearTimeout(timer);
+      setLoading(false);
+      setLoadingStep("");
+    }
+  }
+
+  const tabStyle = (active: boolean) => ({
+    color: active ? "#f5c842" : "rgba(255,255,255,0.4)",
+    borderBottom: active ? "2px solid #f5c842" : "2px solid transparent",
+    background: "transparent",
+  });
 
   return (
     <motion.div
@@ -69,7 +154,7 @@ export function GenerateQuizModal({ onClose, onGenerated }: Props) {
           exit={{ scale: 0.92, opacity: 0, y: 20 }}
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
               <Sparkles className="w-5 h-5" style={{ color: "#f5c842" }} />
               <h3 className="text-lg font-black text-white">Generate with AI</h3>
@@ -85,93 +170,237 @@ export function GenerateQuizModal({ onClose, onGenerated }: Props) {
               <motion.div
                 animate={{ rotate: 360 }}
                 transition={{ duration: 2, repeat: Infinity, ease: "linear" }}>
-                <Sparkles className="w-8 h-8" style={{ color: "#f5c842" }} />
+                {mode === "upload" ? (
+                  <Upload className="w-8 h-8" style={{ color: "#f5c842" }} />
+                ) : (
+                  <Sparkles className="w-8 h-8" style={{ color: "#f5c842" }} />
+                )}
               </motion.div>
               <p className="text-sm font-medium" style={{ color: "rgba(255,255,255,0.7)" }}>
-                Summoning questions from the stars...
+                {loadingStep}
               </p>
             </div>
           ) : (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
-                  Topic <span style={{ color: "#f44336" }}>*</span>
-                </label>
-                <input
-                  type="text"
-                  required
-                  value={topic}
-                  onChange={(e) => setTopic(e.target.value)}
-                  placeholder="e.g. Islamic history, photosynthesis, Premier League"
-                  className="w-full rounded-xl px-4 py-3 text-sm outline-none transition"
-                  style={inputStyle}
-                  onFocus={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.6)")}
-                  onBlur={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.2)")}
-                />
+            <>
+              {/* Tabs */}
+              <div className="flex gap-0 mb-5" style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>
+                <button
+                  type="button"
+                  onClick={() => { setMode("topic"); setError(null); }}
+                  className="flex-1 pb-2.5 text-sm font-semibold transition-colors cursor-pointer"
+                  style={tabStyle(mode === "topic")}
+                >
+                  Topic
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setMode("upload"); setError(null); }}
+                  className="flex-1 pb-2.5 text-sm font-semibold transition-colors cursor-pointer"
+                  style={tabStyle(mode === "upload")}
+                >
+                  Upload Document
+                </button>
               </div>
 
-              <div>
-                <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
-                  Number of questions
-                </label>
-                <input
-                  type="number"
-                  min={1}
-                  max={10}
-                  value={count}
-                  onChange={(e) => setCount(Number(e.target.value))}
-                  className="w-full rounded-xl px-4 py-3 text-sm outline-none transition"
-                  style={{
-                    ...inputStyle,
-                    borderColor: countInvalid ? "rgba(244,67,54,0.5)" : inputStyle.border.split(" ").pop(),
-                  }}
-                  onFocus={(e) => (e.target.style.borderColor = countInvalid ? "rgba(244,67,54,0.7)" : "rgba(245,200,66,0.6)")}
-                  onBlur={(e) => (e.target.style.borderColor = countInvalid ? "rgba(244,67,54,0.5)" : "rgba(245,200,66,0.2)")}
-                />
-                {countInvalid && (
-                  <p className="text-xs mt-1" style={{ color: "#f44336" }}>
-                    Maximum 10 questions for AI generation.
-                  </p>
-                )}
-              </div>
+              {mode === "topic" ? (
+                <form onSubmit={handleTopicSubmit} className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
+                      Topic <span style={{ color: "#f44336" }}>*</span>
+                    </label>
+                    <input
+                      type="text"
+                      required
+                      value={topic}
+                      onChange={(e) => setTopic(e.target.value)}
+                      placeholder="e.g. Islamic history, photosynthesis, Premier League"
+                      className="w-full rounded-xl px-4 py-3 text-sm outline-none transition"
+                      style={inputStyle}
+                      onFocus={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.6)")}
+                      onBlur={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.2)")}
+                    />
+                  </div>
 
-              <div>
-                <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
-                  Additional context <span style={{ color: "rgba(255,255,255,0.3)" }}>(optional)</span>
-                </label>
-                <textarea
-                  value={context}
-                  onChange={(e) => setContext(e.target.value)}
-                  rows={3}
-                  placeholder="e.g. hard difficulty, university level, avoid trick questions"
-                  className="w-full rounded-xl px-4 py-3 text-sm outline-none transition resize-none"
-                  style={inputStyle}
-                  onFocus={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.6)")}
-                  onBlur={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.2)")}
-                />
-              </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
+                      Number of questions
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={10}
+                      value={count}
+                      onChange={(e) => setCount(Number(e.target.value))}
+                      className="w-full rounded-xl px-4 py-3 text-sm outline-none transition"
+                      style={{
+                        ...inputStyle,
+                        borderColor: countInvalid ? "rgba(244,67,54,0.5)" : inputStyle.border.split(" ").pop(),
+                      }}
+                      onFocus={(e) => (e.target.style.borderColor = countInvalid ? "rgba(244,67,54,0.7)" : "rgba(245,200,66,0.6)")}
+                      onBlur={(e) => (e.target.style.borderColor = countInvalid ? "rgba(244,67,54,0.5)" : "rgba(245,200,66,0.2)")}
+                    />
+                    {countInvalid && (
+                      <p className="text-xs mt-1" style={{ color: "#f44336" }}>
+                        Maximum 10 questions for AI generation.
+                      </p>
+                    )}
+                  </div>
 
-              {error && (
-                <div className="text-sm rounded-xl px-4 py-3"
-                  style={{ background: "rgba(244,67,54,0.1)", border: "1px solid rgba(244,67,54,0.3)", color: "#f44336" }}>
-                  {error}
-                </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
+                      Additional context <span style={{ color: "rgba(255,255,255,0.3)" }}>(optional)</span>
+                    </label>
+                    <textarea
+                      value={context}
+                      onChange={(e) => setContext(e.target.value)}
+                      rows={3}
+                      placeholder="e.g. hard difficulty, university level, avoid trick questions"
+                      className="w-full rounded-xl px-4 py-3 text-sm outline-none transition resize-none"
+                      style={inputStyle}
+                      onFocus={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.6)")}
+                      onBlur={(e) => (e.target.style.borderColor = "rgba(245,200,66,0.2)")}
+                    />
+                  </div>
+
+                  {error && (
+                    <div className="text-sm rounded-xl px-4 py-3"
+                      style={{ background: "rgba(244,67,54,0.1)", border: "1px solid rgba(244,67,54,0.3)", color: "#f44336" }}>
+                      {error}
+                    </div>
+                  )}
+
+                  <motion.button
+                    type="submit"
+                    className="w-full py-3 rounded-xl font-bold text-sm flex items-center justify-center gap-2"
+                    style={{
+                      background: "linear-gradient(135deg, #f5c842 0%, #ff6b35 100%)",
+                      color: "white",
+                      boxShadow: "0 6px 24px rgba(245,200,66,0.35)",
+                    }}
+                    whileHover={{ scale: 1.02, boxShadow: "0 8px 30px rgba(245,200,66,0.5)" }}
+                    whileTap={{ scale: 0.98 }}>
+                    <Sparkles className="w-4 h-4" />
+                    Generate Quiz
+                  </motion.button>
+                </form>
+              ) : (
+                <form onSubmit={handleUploadSubmit} className="space-y-4">
+                  {/* File drop zone */}
+                  <div>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".pdf,.docx,.txt,.md"
+                      onChange={handleFileChange}
+                      className="hidden"
+                      data-testid="file-input"
+                    />
+
+                    {!file ? (
+                      <div
+                        onClick={() => fileInputRef.current?.click()}
+                        onDragOver={(e) => e.preventDefault()}
+                        onDrop={handleDrop}
+                        className="rounded-xl p-8 flex flex-col items-center gap-3 cursor-pointer transition-colors"
+                        style={{
+                          border: "2px dashed rgba(245,200,66,0.3)",
+                          background: "rgba(255,255,255,0.03)",
+                        }}
+                        onMouseEnter={(e) => (e.currentTarget.style.borderColor = "rgba(245,200,66,0.5)")}
+                        onMouseLeave={(e) => (e.currentTarget.style.borderColor = "rgba(245,200,66,0.3)")}
+                      >
+                        <Upload className="w-8 h-8" style={{ color: "rgba(245,200,66,0.6)" }} />
+                        <p className="text-sm font-medium" style={{ color: "rgba(255,255,255,0.7)" }}>
+                          Drop a file or click to browse
+                        </p>
+                        <p className="text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>
+                          PDF, DOCX, TXT, MD (max 5MB)
+                        </p>
+                      </div>
+                    ) : (
+                      <div
+                        className="rounded-xl px-4 py-3 flex items-center gap-3"
+                        style={{
+                          background: "rgba(245,200,66,0.08)",
+                          border: "1px solid rgba(245,200,66,0.25)",
+                        }}
+                      >
+                        <FileText className="w-5 h-5 shrink-0" style={{ color: "#f5c842" }} />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-white truncate">{file.name}</p>
+                          <p className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>
+                            {formatFileSize(file.size)}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => { setFile(null); setFileError(null); if (fileInputRef.current) fileInputRef.current.value = ""; }}
+                          className="p-1.5 rounded-lg transition cursor-pointer"
+                          style={{ color: "rgba(255,255,255,0.4)", background: "rgba(255,255,255,0.05)" }}
+                          aria-label="Remove file"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    )}
+
+                    {fileError && (
+                      <p className="text-xs mt-1.5" style={{ color: "#f44336" }}>
+                        {fileError}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Question count */}
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5" style={{ color: "rgba(255,255,255,0.7)" }}>
+                      Number of questions
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={10}
+                      value={count}
+                      onChange={(e) => setCount(Number(e.target.value))}
+                      className="w-full rounded-xl px-4 py-3 text-sm outline-none transition"
+                      style={{
+                        ...inputStyle,
+                        borderColor: countInvalid ? "rgba(244,67,54,0.5)" : inputStyle.border.split(" ").pop(),
+                      }}
+                      onFocus={(e) => (e.target.style.borderColor = countInvalid ? "rgba(244,67,54,0.7)" : "rgba(245,200,66,0.6)")}
+                      onBlur={(e) => (e.target.style.borderColor = countInvalid ? "rgba(244,67,54,0.5)" : "rgba(245,200,66,0.2)")}
+                    />
+                    {countInvalid && (
+                      <p className="text-xs mt-1" style={{ color: "#f44336" }}>
+                        Maximum 10 questions for AI generation.
+                      </p>
+                    )}
+                  </div>
+
+                  {error && (
+                    <div className="text-sm rounded-xl px-4 py-3"
+                      style={{ background: "rgba(244,67,54,0.1)", border: "1px solid rgba(244,67,54,0.3)", color: "#f44336" }}>
+                      {error}
+                    </div>
+                  )}
+
+                  <motion.button
+                    type="submit"
+                    disabled={!file}
+                    className="w-full py-3 rounded-xl font-bold text-sm flex items-center justify-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+                    style={{
+                      background: "linear-gradient(135deg, #f5c842 0%, #ff6b35 100%)",
+                      color: "white",
+                      boxShadow: file ? "0 6px 24px rgba(245,200,66,0.35)" : "none",
+                    }}
+                    whileHover={file ? { scale: 1.02, boxShadow: "0 8px 30px rgba(245,200,66,0.5)" } : {}}
+                    whileTap={file ? { scale: 0.98 } : {}}>
+                    <Upload className="w-4 h-4" />
+                    Generate from Document
+                  </motion.button>
+                </form>
               )}
-
-              <motion.button
-                type="submit"
-                className="w-full py-3 rounded-xl font-bold text-sm flex items-center justify-center gap-2"
-                style={{
-                  background: "linear-gradient(135deg, #f5c842 0%, #ff6b35 100%)",
-                  color: "white",
-                  boxShadow: "0 6px 24px rgba(245,200,66,0.35)",
-                }}
-                whileHover={{ scale: 1.02, boxShadow: "0 8px 30px rgba(245,200,66,0.5)" }}
-                whileTap={{ scale: 0.98 }}>
-                <Sparkles className="w-4 h-4" />
-                Generate Quiz
-              </motion.button>
-            </form>
+            </>
           )}
         </motion.div>
     </motion.div>

--- a/frontend/src/test/GenerateQuizModal.test.tsx
+++ b/frontend/src/test/GenerateQuizModal.test.tsx
@@ -47,4 +47,80 @@ describe("GenerateQuizModal", () => {
     fireEvent.submit(screen.getByRole("button", { name: /generate quiz/i }));
     expect(onGenerated).not.toHaveBeenCalled();
   });
+
+  it("renders both Topic and Upload tabs", () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Topic" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upload Document" })).toBeInTheDocument();
+  });
+
+  it("defaults to Topic tab", () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    expect(screen.getByPlaceholderText(/islamic history/i)).toBeInTheDocument();
+    expect(screen.queryByText(/drop a file/i)).not.toBeInTheDocument();
+  });
+
+  it("switches to Upload tab and shows file picker", async () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole("button", { name: "Upload Document" }));
+    expect(screen.getByText(/drop a file or click to browse/i)).toBeInTheDocument();
+    expect(screen.getByText(/PDF, DOCX, TXT, MD/i)).toBeInTheDocument();
+  });
+
+  it("shows selected filename after picking a valid file", async () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole("button", { name: "Upload Document" }));
+
+    const file = new File(["test content"], "notes.txt", { type: "text/plain" });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+  });
+
+  it("shows file error for unsupported extension", async () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole("button", { name: "Upload Document" }));
+
+    const file = new File(["data"], "sheet.xlsx", { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+    const input = screen.getByTestId("file-input") as HTMLInputElement;
+    // fireEvent bypasses the accept attribute filter that userEvent respects
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(screen.getByText(/unsupported file type/i)).toBeInTheDocument();
+  });
+
+  it("disables submit button when no file selected in upload mode", async () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole("button", { name: "Upload Document" }));
+
+    const submitBtn = screen.getByRole("button", { name: /generate from document/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("enables submit button after selecting a valid file", async () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole("button", { name: "Upload Document" }));
+
+    const file = new File(["test content"], "notes.txt", { type: "text/plain" });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    const submitBtn = screen.getByRole("button", { name: /generate from document/i });
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it("can remove selected file", async () => {
+    render(<GenerateQuizModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole("button", { name: "Upload Document" }));
+
+    const file = new File(["test content"], "notes.txt", { type: "text/plain" });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /remove file/i }));
+    expect(screen.queryByText("notes.txt")).not.toBeInTheDocument();
+    expect(screen.getByText(/drop a file/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

Adds document upload as an alternative input method for AI quiz generation. Admins can now upload PDF, DOCX, TXT, or MD files instead of typing a topic — the AI extracts text from the document and generates quiz questions from it.

### Backend
- New `docextract` package for text extraction (PDF via `ledongthuc/pdf`, DOCX via `archive/zip` + XML parsing, TXT/MD as plaintext)
- Magic bytes validation (`%PDF`, `PK\x03\x04`, UTF-8) and 5MB size limit
- New `POST /quizzes/generate/upload` multipart endpoint
- Refactored shared generation pipeline into `generateQuizFromText()` helper reused by both endpoints
- Rate limiting shared with topic-based endpoint

### Frontend
- Tab UI (Topic | Upload) in GenerateQuizModal with animated underline
- Drag-and-drop file picker with visual feedback
- Client-side validation: file extension + 5MB size check
- Loading state with extraction → generation progress messages
- 13 frontend tests, 8 new backend tests, 13 docextract tests

## Test plan

- [x] Run `./scripts/check.sh` — all checks pass
- [x] Start app, open quiz creation, click "Generate with AI"
- [x] Verify Topic tab works as before (no regression)
- [x] Switch to Upload tab, upload a .txt file → quiz generated
- [x] Upload a .docx file → quiz generated
- [x] Upload a .xlsx → rejected client-side with error message
- [x] Upload a >5MB file → rejected client-side
- [x] Try uploading without selecting a file → submit button disabled
- [x] Verify rate limiting works (same counter for both endpoints)

Closes #99