### PR TITLE
feat(#100): admin analytics dashboard

### DIFF
--- a/backend/internal/handlers/analytics.go
+++ b/backend/internal/handlers/analytics.go
@@ -1,0 +1,521 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	appMiddleware "github.com/HassanA01/Hilal/backend/internal/middleware"
+)
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+type overviewResponse struct {
+	TotalQuizzes      int     `json:"total_quizzes"`
+	TotalGames        int     `json:"total_games"`
+	TotalPlayers      int     `json:"total_players"`
+	TotalAnswers      int     `json:"total_answers"`
+	AvgPlayersPerGame float64 `json:"avg_players_per_game"`
+	AvgScore          float64 `json:"avg_score"`
+}
+
+type timeSeriesPoint struct {
+	Date    string `json:"date"`
+	Games   int    `json:"games"`
+	Players int    `json:"players"`
+}
+
+type quizStatsResponse struct {
+	ID            string  `json:"id"`
+	Title         string  `json:"title"`
+	Plays         int     `json:"plays"`
+	AvgScore      float64 `json:"avg_score"`
+	PlayerCount   int     `json:"player_count"`
+	QuestionCount int     `json:"question_count"`
+	CreatedAt     string  `json:"created_at"`
+}
+
+type optionDistribution struct {
+	Text  string  `json:"text"`
+	Count int     `json:"count"`
+	Pct   float64 `json:"pct"`
+}
+
+type questionStatsResponse struct {
+	ID           string               `json:"id"`
+	Text         string               `json:"text"`
+	Type         string               `json:"type"`
+	Order        int                  `json:"order"`
+	CorrectPct   float64              `json:"correct_pct"`
+	AvgPoints    float64              `json:"avg_points"`
+	TotalAnswers int                  `json:"total_answers"`
+	Options      []optionDistribution `json:"options"`
+}
+
+type playerStatsResponse struct {
+	Name        string  `json:"name"`
+	TotalScore  int     `json:"total_score"`
+	GamesPlayed int     `json:"games_played"`
+	AvgScore    float64 `json:"avg_score"`
+	AvgSpeedMs  float64 `json:"avg_speed_ms"`
+}
+
+type peakHourBucket struct {
+	DayOfWeek int `json:"day_of_week"`
+	Hour      int `json:"hour"`
+	Count     int `json:"count"`
+}
+
+type engagementResponse struct {
+	PeakHours       []peakHourBucket `json:"peak_hours"`
+	AvgGameDuration float64          `json:"avg_game_duration_seconds"`
+}
+
+// ---------------------------------------------------------------------------
+// 1. AnalyticsOverview — GET /analytics/overview
+// ---------------------------------------------------------------------------
+
+func (h *Handler) AnalyticsOverview(w http.ResponseWriter, r *http.Request) {
+	adminID := appMiddleware.GetAdminID(r.Context())
+
+	query := `
+		WITH admin_quizzes AS (
+			SELECT id FROM quizzes WHERE admin_id = $1
+		),
+		admin_sessions AS (
+			SELECT gs.id
+			FROM game_sessions gs
+			JOIN admin_quizzes aq ON aq.id = gs.quiz_id
+		),
+		admin_players AS (
+			SELECT gp.id, gp.score
+			FROM game_players gp
+			JOIN admin_sessions asess ON asess.id = gp.session_id
+		),
+		admin_answers AS (
+			SELECT ga.id
+			FROM game_answers ga
+			JOIN admin_sessions asess ON asess.id = ga.session_id
+		)
+		SELECT
+			(SELECT COUNT(*) FROM admin_quizzes),
+			(SELECT COUNT(*) FROM admin_sessions),
+			(SELECT COUNT(*) FROM admin_players),
+			(SELECT COUNT(*) FROM admin_answers),
+			COALESCE((SELECT COUNT(*)::float FROM admin_players) /
+				NULLIF((SELECT COUNT(*) FROM admin_sessions), 0), 0),
+			COALESCE((SELECT AVG(score)::float FROM admin_players), 0)
+	`
+
+	var resp overviewResponse
+	err := h.db.QueryRow(r.Context(), query, adminID).Scan(
+		&resp.TotalQuizzes,
+		&resp.TotalGames,
+		&resp.TotalPlayers,
+		&resp.TotalAnswers,
+		&resp.AvgPlayersPerGame,
+		&resp.AvgScore,
+	)
+	if err != nil {
+		slog.Error("analytics overview query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load analytics overview")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ---------------------------------------------------------------------------
+// 2. AnalyticsGamesOverTime — GET /analytics/games-over-time?period=day|week|month&range=7d|30d|90d|all
+// ---------------------------------------------------------------------------
+
+func (h *Handler) AnalyticsGamesOverTime(w http.ResponseWriter, r *http.Request) {
+	adminID := appMiddleware.GetAdminID(r.Context())
+
+	// Validate period
+	period := r.URL.Query().Get("period")
+	allowedPeriods := map[string]bool{"day": true, "week": true, "month": true}
+	if !allowedPeriods[period] {
+		period = "day"
+	}
+
+	// Parse range to a date filter
+	rangeParam := r.URL.Query().Get("range")
+	var dateFilter string
+	switch rangeParam {
+	case "7d":
+		dateFilter = time.Now().AddDate(0, 0, -7).Format(time.RFC3339)
+	case "30d":
+		dateFilter = time.Now().AddDate(0, 0, -30).Format(time.RFC3339)
+	case "90d":
+		dateFilter = time.Now().AddDate(0, 0, -90).Format(time.RFC3339)
+	default:
+		// "all" or anything else — no lower bound
+		dateFilter = ""
+	}
+
+	query := `
+		SELECT
+			TO_CHAR(DATE_TRUNC('` + period + `', gs.created_at), 'YYYY-MM-DD') AS date,
+			COUNT(DISTINCT gs.id) AS games,
+			COUNT(DISTINCT gp.id) AS players
+		FROM game_sessions gs
+		JOIN quizzes q ON q.id = gs.quiz_id
+		LEFT JOIN game_players gp ON gp.session_id = gs.id
+		WHERE q.admin_id = $1
+	`
+	args := []any{adminID}
+
+	if dateFilter != "" {
+		query += ` AND gs.created_at >= $2`
+		args = append(args, dateFilter)
+	}
+
+	query += `
+		GROUP BY DATE_TRUNC('` + period + `', gs.created_at)
+		ORDER BY date ASC
+	`
+
+	rows, err := h.db.Query(r.Context(), query, args...)
+	if err != nil {
+		slog.Error("analytics games-over-time query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load games over time")
+		return
+	}
+	defer rows.Close()
+
+	result := []timeSeriesPoint{}
+	for rows.Next() {
+		var p timeSeriesPoint
+		if err := rows.Scan(&p.Date, &p.Games, &p.Players); err != nil {
+			slog.Error("analytics games-over-time scan failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to read games over time")
+			return
+		}
+		result = append(result, p)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("analytics games-over-time rows error", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to read games over time")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// ---------------------------------------------------------------------------
+// 3. AnalyticsQuizzes — GET /analytics/quizzes?sort=plays|avg_score|completion&order=asc|desc
+// ---------------------------------------------------------------------------
+
+func (h *Handler) AnalyticsQuizzes(w http.ResponseWriter, r *http.Request) {
+	adminID := appMiddleware.GetAdminID(r.Context())
+
+	// Whitelist sort columns
+	sortColumns := map[string]string{
+		"plays":      "plays",
+		"avg_score":  "avg_score",
+		"completion": "plays", // alias — no explicit completion rate column
+	}
+	sortParam := r.URL.Query().Get("sort")
+	sortCol, ok := sortColumns[sortParam]
+	if !ok {
+		sortCol = "plays"
+	}
+
+	orderParam := r.URL.Query().Get("order")
+	if orderParam != "asc" {
+		orderParam = "desc"
+	}
+
+	query := `
+		SELECT
+			q.id,
+			q.title,
+			COUNT(DISTINCT gs.id) AS plays,
+			COALESCE(AVG(gp.score)::float, 0) AS avg_score,
+			COUNT(DISTINCT gp.id) AS player_count,
+			(SELECT COUNT(*) FROM questions WHERE quiz_id = q.id) AS question_count,
+			TO_CHAR(q.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at
+		FROM quizzes q
+		LEFT JOIN game_sessions gs ON gs.quiz_id = q.id
+		LEFT JOIN game_players gp ON gp.session_id = gs.id
+		WHERE q.admin_id = $1
+		GROUP BY q.id, q.title, q.created_at
+		ORDER BY ` + sortCol + ` ` + orderParam + `
+	`
+
+	rows, err := h.db.Query(r.Context(), query, adminID)
+	if err != nil {
+		slog.Error("analytics quizzes query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load quiz analytics")
+		return
+	}
+	defer rows.Close()
+
+	result := []quizStatsResponse{}
+	for rows.Next() {
+		var qs quizStatsResponse
+		if err := rows.Scan(&qs.ID, &qs.Title, &qs.Plays, &qs.AvgScore,
+			&qs.PlayerCount, &qs.QuestionCount, &qs.CreatedAt); err != nil {
+			slog.Error("analytics quizzes scan failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to read quiz analytics")
+			return
+		}
+		result = append(result, qs)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("analytics quizzes rows error", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to read quiz analytics")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// ---------------------------------------------------------------------------
+// 4. AnalyticsQuizQuestions — GET /analytics/quizzes/{quizID}/questions
+// ---------------------------------------------------------------------------
+
+func (h *Handler) AnalyticsQuizQuestions(w http.ResponseWriter, r *http.Request) {
+	adminID := appMiddleware.GetAdminID(r.Context())
+	quizID := chi.URLParam(r, "quizID")
+
+	// Verify quiz belongs to admin
+	var exists bool
+	err := h.db.QueryRow(r.Context(),
+		`SELECT EXISTS(SELECT 1 FROM quizzes WHERE id = $1 AND admin_id = $2)`,
+		quizID, adminID,
+	).Scan(&exists)
+	if err != nil || !exists {
+		writeError(w, http.StatusNotFound, "quiz not found")
+		return
+	}
+
+	// Fetch questions with answer stats
+	qRows, err := h.db.Query(r.Context(), `
+		SELECT
+			qu.id,
+			qu.text,
+			qu.type,
+			qu."order",
+			COALESCE(
+				SUM(CASE WHEN ga.is_correct THEN 1 ELSE 0 END)::float /
+				NULLIF(COUNT(ga.id), 0) * 100,
+			0) AS correct_pct,
+			COALESCE(AVG(ga.points)::float, 0) AS avg_points,
+			COUNT(ga.id) AS total_answers
+		FROM questions qu
+		LEFT JOIN game_answers ga ON ga.question_id = qu.id
+		WHERE qu.quiz_id = $1
+		GROUP BY qu.id, qu.text, qu.type, qu."order"
+		ORDER BY qu."order" ASC
+	`, quizID)
+	if err != nil {
+		slog.Error("analytics quiz questions query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load question analytics")
+		return
+	}
+	defer qRows.Close()
+
+	result := []questionStatsResponse{}
+	for qRows.Next() {
+		var qs questionStatsResponse
+		if err := qRows.Scan(&qs.ID, &qs.Text, &qs.Type, &qs.Order,
+			&qs.CorrectPct, &qs.AvgPoints, &qs.TotalAnswers); err != nil {
+			slog.Error("analytics quiz questions scan failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to read question analytics")
+			return
+		}
+
+		// Fetch option distribution for this question
+		optRows, err := h.db.Query(r.Context(), `
+			SELECT
+				o.text,
+				COUNT(ga.id) AS count,
+				COALESCE(
+					COUNT(ga.id)::float /
+					NULLIF((SELECT COUNT(*) FROM game_answers WHERE question_id = $1), 0) * 100,
+				0) AS pct
+			FROM options o
+			LEFT JOIN game_answers ga ON ga.option_id = o.id AND ga.question_id = $1
+			WHERE o.question_id = $1
+			GROUP BY o.id, o.text, o.sort_order
+			ORDER BY o.sort_order ASC
+		`, qs.ID)
+		if err != nil {
+			slog.Error("analytics option distribution query failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to load option distribution")
+			return
+		}
+
+		qs.Options = []optionDistribution{}
+		for optRows.Next() {
+			var od optionDistribution
+			if err := optRows.Scan(&od.Text, &od.Count, &od.Pct); err != nil {
+				optRows.Close()
+				slog.Error("analytics option distribution scan failed", "error", err)
+				writeError(w, http.StatusInternalServerError, "failed to read option distribution")
+				return
+			}
+			qs.Options = append(qs.Options, od)
+		}
+		optRows.Close()
+		if err := optRows.Err(); err != nil {
+			slog.Error("analytics option distribution rows error", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to read option distribution")
+			return
+		}
+
+		result = append(result, qs)
+	}
+	if err := qRows.Err(); err != nil {
+		slog.Error("analytics quiz questions rows error", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to read question analytics")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// ---------------------------------------------------------------------------
+// 5. AnalyticsTopPlayers — GET /analytics/players?sort=score|games|speed&limit=20
+// ---------------------------------------------------------------------------
+
+func (h *Handler) AnalyticsTopPlayers(w http.ResponseWriter, r *http.Request) {
+	adminID := appMiddleware.GetAdminID(r.Context())
+
+	// Whitelist sort columns
+	sortColumns := map[string]string{
+		"score": "total_score",
+		"games": "games_played",
+		"speed": "avg_speed_ms",
+	}
+	sortParam := r.URL.Query().Get("sort")
+	sortCol, ok := sortColumns[sortParam]
+	if !ok {
+		sortCol = "total_score"
+	}
+
+	// Parse limit
+	limit := 20
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	query := `
+		SELECT
+			gp.name,
+			COALESCE(SUM(gp.score), 0) AS total_score,
+			COUNT(DISTINCT gp.session_id) AS games_played,
+			COALESCE(AVG(gp.score)::float, 0) AS avg_score,
+			0::float AS avg_speed_ms
+		FROM game_players gp
+		JOIN game_sessions gs ON gs.id = gp.session_id
+		JOIN quizzes q ON q.id = gs.quiz_id
+		WHERE q.admin_id = $1
+		GROUP BY gp.name
+		ORDER BY ` + sortCol + ` DESC
+		LIMIT $2
+	`
+
+	rows, err := h.db.Query(r.Context(), query, adminID, limit)
+	if err != nil {
+		slog.Error("analytics top players query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load player analytics")
+		return
+	}
+	defer rows.Close()
+
+	result := []playerStatsResponse{}
+	for rows.Next() {
+		var ps playerStatsResponse
+		if err := rows.Scan(&ps.Name, &ps.TotalScore, &ps.GamesPlayed,
+			&ps.AvgScore, &ps.AvgSpeedMs); err != nil {
+			slog.Error("analytics top players scan failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to read player analytics")
+			return
+		}
+		result = append(result, ps)
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("analytics top players rows error", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to read player analytics")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// ---------------------------------------------------------------------------
+// 6. AnalyticsEngagement — GET /analytics/engagement
+// ---------------------------------------------------------------------------
+
+func (h *Handler) AnalyticsEngagement(w http.ResponseWriter, r *http.Request) {
+	adminID := appMiddleware.GetAdminID(r.Context())
+
+	// Peak hours
+	peakRows, err := h.db.Query(r.Context(), `
+		SELECT
+			EXTRACT(dow FROM gs.started_at)::int AS day_of_week,
+			EXTRACT(hour FROM gs.started_at)::int AS hour,
+			COUNT(*) AS count
+		FROM game_sessions gs
+		JOIN quizzes q ON q.id = gs.quiz_id
+		WHERE q.admin_id = $1 AND gs.started_at IS NOT NULL
+		GROUP BY day_of_week, hour
+		ORDER BY count DESC
+	`, adminID)
+	if err != nil {
+		slog.Error("analytics engagement peak hours query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load engagement analytics")
+		return
+	}
+	defer peakRows.Close()
+
+	peakHours := []peakHourBucket{}
+	for peakRows.Next() {
+		var b peakHourBucket
+		if err := peakRows.Scan(&b.DayOfWeek, &b.Hour, &b.Count); err != nil {
+			slog.Error("analytics engagement peak hours scan failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to read engagement analytics")
+			return
+		}
+		peakHours = append(peakHours, b)
+	}
+	if err := peakRows.Err(); err != nil {
+		slog.Error("analytics engagement peak hours rows error", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to read engagement analytics")
+		return
+	}
+
+	// Avg game duration
+	var avgDuration float64
+	err = h.db.QueryRow(r.Context(), `
+		SELECT COALESCE(AVG(EXTRACT(EPOCH FROM (gs.ended_at - gs.started_at))), 0)
+		FROM game_sessions gs
+		JOIN quizzes q ON q.id = gs.quiz_id
+		WHERE q.admin_id = $1 AND gs.started_at IS NOT NULL AND gs.ended_at IS NOT NULL
+	`, adminID).Scan(&avgDuration)
+	if err != nil {
+		slog.Error("analytics engagement avg duration query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load engagement analytics")
+		return
+	}
+
+	resp := engagementResponse{
+		PeakHours:       peakHours,
+		AvgGameDuration: avgDuration,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/backend/internal/handlers/analytics_test.go
+++ b/backend/internal/handlers/analytics_test.go
@@ -1,0 +1,443 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
+
+	appMiddleware "github.com/HassanA01/Hilal/backend/internal/middleware"
+)
+
+// analyticsRouter returns a chi router with Recoverer middleware and a single
+// route wired to the given handler method. Recoverer catches nil-DB panics and
+// turns them into 500 responses, matching production behavior.
+func analyticsRouter(method, pattern string, handlerFn http.HandlerFunc) *chi.Mux {
+	r := chi.NewRouter()
+	r.Use(chimw.Recoverer)
+	r.MethodFunc(method, pattern, handlerFn)
+	return r
+}
+
+// analyticsRequest builds a GET request to the given URL with admin ID in context.
+func analyticsRequest(url, adminID string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	ctx := appMiddleware.ContextWithAdminID(req.Context(), adminID)
+	return req.WithContext(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsOverview
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsOverview_NilDB(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/overview", h.AnalyticsOverview)
+
+	req := analyticsRequest("/analytics/overview", "test-admin-id")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsGamesOverTime
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsGamesOverTime_NilDB(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/games-over-time", h.AnalyticsGamesOverTime)
+
+	req := analyticsRequest("/analytics/games-over-time", "test-admin-id")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAnalyticsGamesOverTime_Params(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/games-over-time", h.AnalyticsGamesOverTime)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"defaults", "/analytics/games-over-time"},
+		{"period day", "/analytics/games-over-time?period=day"},
+		{"period week", "/analytics/games-over-time?period=week"},
+		{"period month", "/analytics/games-over-time?period=month"},
+		{"range 7d", "/analytics/games-over-time?range=7d"},
+		{"range 30d", "/analytics/games-over-time?range=30d"},
+		{"range 90d", "/analytics/games-over-time?range=90d"},
+		{"range all", "/analytics/games-over-time?range=all"},
+		{"invalid period defaults", "/analytics/games-over-time?period=invalid"},
+		{"combined params", "/analytics/games-over-time?period=week&range=30d"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := analyticsRequest(tc.url, "test-admin-id")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			// All should reach the DB call (nil) and get 500 via Recoverer — not panic.
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsQuizzes
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsQuizzes_NilDB(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/quizzes-stats", h.AnalyticsQuizzes)
+
+	req := analyticsRequest("/analytics/quizzes-stats", "test-admin-id")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAnalyticsQuizzes_SortAndOrder(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/quizzes-stats", h.AnalyticsQuizzes)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"default sort", "/analytics/quizzes-stats"},
+		{"sort by plays", "/analytics/quizzes-stats?sort=plays"},
+		{"sort by avg_score", "/analytics/quizzes-stats?sort=avg_score"},
+		{"sort by completion", "/analytics/quizzes-stats?sort=completion"},
+		{"invalid sort defaults", "/analytics/quizzes-stats?sort=invalid"},
+		{"order asc", "/analytics/quizzes-stats?order=asc"},
+		{"order desc", "/analytics/quizzes-stats?order=desc"},
+		{"invalid order defaults to desc", "/analytics/quizzes-stats?order=invalid"},
+		{"combined sort and order", "/analytics/quizzes-stats?sort=avg_score&order=asc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := analyticsRequest(tc.url, "test-admin-id")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsQuizQuestions
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsQuizQuestions_NilDB(t *testing.T) {
+	h := newTestHandler()
+
+	r := chi.NewRouter()
+	r.Use(chimw.Recoverer)
+	r.Get("/analytics/quizzes/{quizID}/questions", h.AnalyticsQuizQuestions)
+
+	req := analyticsRequest(
+		"/analytics/quizzes/00000000-0000-0000-0000-000000000001/questions",
+		"test-admin-id",
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// The handler calls h.db.QueryRow on the ownership check — nil DB → 500 via Recoverer.
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAnalyticsQuizQuestions_URLParamParsed(t *testing.T) {
+	h := newTestHandler()
+
+	r := chi.NewRouter()
+	r.Use(chimw.Recoverer)
+	r.Get("/analytics/quizzes/{quizID}/questions", h.AnalyticsQuizQuestions)
+
+	uuids := []string{
+		"00000000-0000-0000-0000-000000000001",
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	}
+	for _, id := range uuids {
+		t.Run(id, func(t *testing.T) {
+			req := analyticsRequest(
+				"/analytics/quizzes/"+id+"/questions",
+				"test-admin-id",
+			)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			// Regardless of UUID value, nil DB means 500.
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsTopPlayers
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsTopPlayers_NilDB(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/players", h.AnalyticsTopPlayers)
+
+	req := analyticsRequest("/analytics/players", "test-admin-id")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAnalyticsTopPlayers_LimitParams(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/players", h.AnalyticsTopPlayers)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"default limit", "/analytics/players"},
+		{"limit 10", "/analytics/players?limit=10"},
+		{"limit 1", "/analytics/players?limit=1"},
+		{"limit 100", "/analytics/players?limit=100"},
+		{"limit exceeds max clamped to 100", "/analytics/players?limit=999"},
+		{"negative limit defaults to 20", "/analytics/players?limit=-1"},
+		{"zero limit defaults to 20", "/analytics/players?limit=0"},
+		{"non-numeric limit defaults to 20", "/analytics/players?limit=abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := analyticsRequest(tc.url, "test-admin-id")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			// All reach DB → nil DB → 500.
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAnalyticsTopPlayers_SortParams(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/players", h.AnalyticsTopPlayers)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"default sort", "/analytics/players"},
+		{"sort by score", "/analytics/players?sort=score"},
+		{"sort by games", "/analytics/players?sort=games"},
+		{"sort by speed", "/analytics/players?sort=speed"},
+		{"invalid sort defaults", "/analytics/players?sort=invalid"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := analyticsRequest(tc.url, "test-admin-id")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsEngagement
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsEngagement_NilDB(t *testing.T) {
+	h := newTestHandler()
+	r := analyticsRouter(http.MethodGet, "/analytics/engagement", h.AnalyticsEngagement)
+
+	req := analyticsRequest("/analytics/engagement", "test-admin-id")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d — body: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Response type JSON marshalling
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsResponseTypes_JSONShape(t *testing.T) {
+	t.Run("overviewResponse", func(t *testing.T) {
+		resp := overviewResponse{
+			TotalQuizzes:      5,
+			TotalGames:        20,
+			TotalPlayers:      100,
+			TotalAnswers:      400,
+			AvgPlayersPerGame: 5.0,
+			AvgScore:          750.5,
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		expectedKeys := []string{
+			"total_quizzes", "total_games", "total_players",
+			"total_answers", "avg_players_per_game", "avg_score",
+		}
+		for _, k := range expectedKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing JSON key %q", k)
+			}
+		}
+	})
+
+	t.Run("timeSeriesPoint", func(t *testing.T) {
+		p := timeSeriesPoint{Date: "2025-01-01", Games: 3, Players: 12}
+		data, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"date", "games", "players"} {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing JSON key %q", k)
+			}
+		}
+	})
+
+	t.Run("quizStatsResponse", func(t *testing.T) {
+		qs := quizStatsResponse{
+			ID: "abc", Title: "Test", Plays: 10,
+			AvgScore: 800, PlayerCount: 50, QuestionCount: 5,
+			CreatedAt: "2025-01-01T00:00:00Z",
+		}
+		data, err := json.Marshal(qs)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		expectedKeys := []string{
+			"id", "title", "plays", "avg_score",
+			"player_count", "question_count", "created_at",
+		}
+		for _, k := range expectedKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing JSON key %q", k)
+			}
+		}
+	})
+
+	t.Run("questionStatsResponse", func(t *testing.T) {
+		qs := questionStatsResponse{
+			ID: "q1", Text: "What?", Type: "multiple_choice",
+			Order: 1, CorrectPct: 75.0, AvgPoints: 800,
+			TotalAnswers: 20,
+			Options: []optionDistribution{
+				{Text: "A", Count: 15, Pct: 75.0},
+				{Text: "B", Count: 5, Pct: 25.0},
+			},
+		}
+		data, err := json.Marshal(qs)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		expectedKeys := []string{
+			"id", "text", "type", "order",
+			"correct_pct", "avg_points", "total_answers", "options",
+		}
+		for _, k := range expectedKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing JSON key %q", k)
+			}
+		}
+		opts, ok := m["options"].([]any)
+		if !ok || len(opts) != 2 {
+			t.Errorf("expected options array with 2 items, got %v", m["options"])
+		}
+	})
+
+	t.Run("playerStatsResponse", func(t *testing.T) {
+		ps := playerStatsResponse{
+			Name: "Alice", TotalScore: 5000, GamesPlayed: 3,
+			AvgScore: 1666.67, AvgSpeedMs: 1200.5,
+		}
+		data, err := json.Marshal(ps)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		expectedKeys := []string{
+			"name", "total_score", "games_played", "avg_score", "avg_speed_ms",
+		}
+		for _, k := range expectedKeys {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing JSON key %q", k)
+			}
+		}
+	})
+
+	t.Run("engagementResponse", func(t *testing.T) {
+		resp := engagementResponse{
+			PeakHours: []peakHourBucket{
+				{DayOfWeek: 1, Hour: 14, Count: 5},
+			},
+			AvgGameDuration: 120.5,
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"peak_hours", "avg_game_duration_seconds"} {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing JSON key %q", k)
+			}
+		}
+	})
+}

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -77,6 +77,14 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 
 			// Image uploads (admin only)
 			r.Post("/uploads/image", h.UploadImage)
+
+			// Analytics (admin only)
+			r.Get("/analytics/overview", h.AnalyticsOverview)
+			r.Get("/analytics/games-over-time", h.AnalyticsGamesOverTime)
+			r.Get("/analytics/quizzes", h.AnalyticsQuizzes)
+			r.Get("/analytics/quizzes/{quizID}/questions", h.AnalyticsQuizQuestions)
+			r.Get("/analytics/players", h.AnalyticsTopPlayers)
+			r.Get("/analytics/engagement", h.AnalyticsEngagement)
 		})
 
 		// Uploaded images (public — players need to see them)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.0",
     "tailwindcss": "^4.2.1",
     "zustand": "^5.0.11"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -35,12 +35,15 @@ importers:
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      recharts:
+        specifier: ^3.8.0
+        version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
       zustand:
         specifier: ^5.0.11
-        version: 5.0.11(@types/react@19.2.14)(react@19.2.4)
+        version: 5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -495,6 +498,17 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -638,6 +652,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
@@ -788,6 +805,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -807,6 +851,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -1009,6 +1056,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1048,6 +1099,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1060,6 +1155,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1118,6 +1216,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1211,6 +1312,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1363,6 +1467,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1374,6 +1484,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1698,6 +1812,18 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -1723,13 +1849,32 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1806,6 +1951,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1876,6 +2024,14 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -2346,6 +2502,18 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2424,6 +2592,8 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.2.1':
     dependencies:
@@ -2562,6 +2732,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -2579,6 +2773,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2828,6 +3024,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2866,6 +3064,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -2876,6 +3112,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -2922,6 +3160,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -3058,6 +3298,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3188,6 +3430,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3196,6 +3442,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  internmap@2.0.3: {}
 
   is-extglob@2.1.1: {}
 
@@ -3471,6 +3719,15 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-refresh@0.18.0: {}
 
   react-router-dom@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -3489,12 +3746,40 @@ snapshots:
 
   react@19.2.4: {}
 
+  recharts@3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -3575,6 +3860,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -3636,6 +3923,27 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@7.3.1(@types/node@24.10.14)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
@@ -3730,7 +4038,9 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4):
+  zustand@5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.14
+      immer: 11.1.4
       react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { QuizFormPage } from "./pages/QuizFormPage";
 import { HostLobbyPage } from "./pages/HostLobbyPage";
 import { HostGamePage } from "./pages/HostGamePage";
 import { SessionHistoryPage } from "./pages/SessionHistoryPage";
+import { AnalyticsDashboardPage } from "./pages/AnalyticsDashboardPage";
 import { JoinPage } from "./pages/JoinPage";
 import { PlayerLobbyPage } from "./pages/PlayerLobbyPage";
 import { PlayerGamePage } from "./pages/PlayerGamePage";
@@ -58,6 +59,7 @@ function App() {
             <Route path="quizzes/new" element={<QuizFormPage />} />
             <Route path="quizzes/:quizID/edit" element={<QuizFormPage />} />
             <Route path="history" element={<SessionHistoryPage />} />
+            <Route path="analytics" element={<AnalyticsDashboardPage />} />
           </Route>
 
           {/* Full-screen admin game routes — outside dashboard shell to avoid double layout */}

--- a/frontend/src/api/analytics.ts
+++ b/frontend/src/api/analytics.ts
@@ -1,0 +1,45 @@
+import { apiClient } from "./client";
+import type {
+  OverviewStats,
+  TimeSeriesPoint,
+  QuizStats,
+  QuestionStats,
+  PlayerStats,
+  EngagementData,
+} from "../types";
+
+export async function fetchOverview(): Promise<OverviewStats> {
+  const { data } = await apiClient.get<OverviewStats>("/analytics/overview");
+  return data;
+}
+
+export async function fetchGamesOverTime(period: string, range: string): Promise<TimeSeriesPoint[]> {
+  const { data } = await apiClient.get<TimeSeriesPoint[]>("/analytics/games-over-time", {
+    params: { period, range },
+  });
+  return data;
+}
+
+export async function fetchQuizPerformance(sort: string, order: string): Promise<QuizStats[]> {
+  const { data } = await apiClient.get<QuizStats[]>("/analytics/quizzes", {
+    params: { sort, order },
+  });
+  return data;
+}
+
+export async function fetchQuizQuestions(quizId: string): Promise<QuestionStats[]> {
+  const { data } = await apiClient.get<QuestionStats[]>(`/analytics/quizzes/${quizId}/questions`);
+  return data;
+}
+
+export async function fetchTopPlayers(sort: string, limit: number): Promise<PlayerStats[]> {
+  const { data } = await apiClient.get<PlayerStats[]>("/analytics/players", {
+    params: { sort, limit },
+  });
+  return data;
+}
+
+export async function fetchEngagement(): Promise<EngagementData> {
+  const { data } = await apiClient.get<EngagementData>("/analytics/engagement");
+  return data;
+}

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -56,6 +56,16 @@ export function AdminDashboardPage() {
                 : { color: "#f5c842" }}>
               History
             </NavLink>
+            <NavLink to="/admin/analytics"
+              className={({ isActive }) =>
+                `px-2.5 sm:px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+                  isActive ? "font-bold" : "opacity-70 hover:opacity-100"
+                }`}
+              style={({ isActive }) => isActive
+                ? { background: "#f5c842", color: "#1a0a2e" }
+                : { color: "#f5c842" }}>
+              Analytics
+            </NavLink>
           </nav>
         </div>
 

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -1,0 +1,770 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion } from "motion/react";
+import {
+  BookOpen,
+  Gamepad2,
+  Users,
+  MessageSquare,
+  UserCheck,
+  Trophy,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+} from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  fetchOverview,
+  fetchGamesOverTime,
+  fetchQuizPerformance,
+  fetchQuizQuestions,
+  fetchTopPlayers,
+  fetchEngagement,
+} from "../api/analytics";
+import type {
+  OverviewStats,
+  QuizStats,
+  QuestionStats,
+  OptionDistribution,
+  PeakHourBucket,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmt(n: number, decimals = 0): string {
+  if (Number.isNaN(n) || n == null) return "0";
+  if (Number.isInteger(n) && decimals === 0) return n.toLocaleString();
+  return n.toFixed(decimals);
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-components
+// ---------------------------------------------------------------------------
+
+function LoadingDots() {
+  return (
+    <div className="flex gap-3 justify-center py-12">
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          className="w-3 h-3 rounded-full"
+          style={{ background: "#f5c842" }}
+          animate={{ scale: [1, 1.5, 1], opacity: [0.5, 1, 0.5] }}
+          transition={{ duration: 1.2, repeat: Infinity, delay: i * 0.2 }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ErrorBox({ message }: { message: string }) {
+  return (
+    <div
+      className="text-center py-12 rounded-2xl"
+      style={{
+        background: "rgba(244,67,54,0.1)",
+        border: "1px solid rgba(244,67,54,0.3)",
+      }}
+    >
+      <p style={{ color: "#f44336" }}>{message}</p>
+    </div>
+  );
+}
+
+function SectionCard({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={`rounded-2xl p-5 sm:p-6 ${className}`}
+      style={{
+        background: "linear-gradient(135deg, rgba(42,20,66,0.7) 0%, rgba(30,15,50,0.8) 100%)",
+        border: "1px solid rgba(245,200,66,0.12)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ToggleGroup({
+  options,
+  value,
+  onChange,
+}: {
+  options: { label: string; value: string }[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex gap-1">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          onClick={() => onChange(o.value)}
+          className="px-3 py-1 rounded-lg text-xs font-semibold transition-all"
+          style={
+            value === o.value
+              ? { background: "#f5c842", color: "#1a0a2e" }
+              : { color: "#f5c842", opacity: 0.7 }
+          }
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom Recharts tooltip
+// ---------------------------------------------------------------------------
+
+function ChartTooltip({ active, payload, label }: { active?: boolean; payload?: Array<{ value: number; dataKey: string }>; label?: string }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div
+      className="rounded-lg px-3 py-2 text-xs shadow-lg"
+      style={{
+        background: "rgba(20,10,40,0.95)",
+        border: "1px solid rgba(245,200,66,0.25)",
+      }}
+    >
+      <p className="font-semibold text-white mb-1">{label}</p>
+      {payload.map((p) => (
+        <p key={p.dataKey} style={{ color: "rgba(255,255,255,0.7)" }}>
+          {p.dataKey === "games" ? "Games" : "Players"}: <span className="font-bold text-white">{p.value}</span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Overview cards config
+// ---------------------------------------------------------------------------
+
+const OVERVIEW_CARDS: {
+  key: keyof OverviewStats;
+  label: string;
+  icon: React.ElementType;
+  decimal?: number;
+}[] = [
+  { key: "total_quizzes", label: "Total Quizzes", icon: BookOpen },
+  { key: "total_games", label: "Total Games", icon: Gamepad2 },
+  { key: "total_players", label: "Total Players", icon: Users },
+  { key: "total_answers", label: "Total Answers", icon: MessageSquare },
+  { key: "avg_players_per_game", label: "Avg Players / Game", icon: UserCheck, decimal: 1 },
+  { key: "avg_score", label: "Avg Score", icon: Trophy, decimal: 1 },
+];
+
+// ---------------------------------------------------------------------------
+// Peak-hours heatmap helpers
+// ---------------------------------------------------------------------------
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function buildHeatmapGrid(buckets: PeakHourBucket[]): number[][] {
+  // grid[day][hour] = count
+  const grid: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+  for (const b of buckets) {
+    grid[b.day_of_week][b.hour] = b.count;
+  }
+  return grid;
+}
+
+function heatColor(count: number, max: number): string {
+  if (max === 0 || count === 0) return "rgba(245,200,66,0.04)";
+  const intensity = count / max;
+  // interpolate opacity from 0.1 to 0.9
+  const alpha = 0.1 + intensity * 0.8;
+  return `rgba(245,200,66,${alpha.toFixed(2)})`;
+}
+
+// ---------------------------------------------------------------------------
+// Question drill-down sub-component
+// ---------------------------------------------------------------------------
+
+function QuestionDrillDown({ quizId }: { quizId: string }) {
+  const { data: questions, isLoading, isError } = useQuery({
+    queryKey: ["analytics", "quiz-questions", quizId],
+    queryFn: () => fetchQuizQuestions(quizId),
+    enabled: !!quizId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (isLoading) return <LoadingDots />;
+  if (isError) return <ErrorBox message="Failed to load question data." />;
+  if (!questions || questions.length === 0) {
+    return (
+      <p className="text-sm py-4 text-center" style={{ color: "rgba(255,255,255,0.4)" }}>
+        No question data available.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-3 space-y-4">
+      {questions.map((q: QuestionStats) => (
+        <div
+          key={q.id}
+          className="rounded-xl p-4"
+          style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(245,200,66,0.08)" }}
+        >
+          <div className="flex flex-wrap items-center gap-3 mb-3">
+            <span className="text-xs font-bold px-2 py-0.5 rounded" style={{ background: "rgba(245,200,66,0.15)", color: "#f5c842" }}>
+              Q{q.order + 1}
+            </span>
+            <span className="text-xs" style={{ color: "rgba(255,255,255,0.4)" }}>{q.type}</span>
+          </div>
+          <p className="text-sm text-white font-medium mb-3">{q.text}</p>
+
+          <div className="flex flex-wrap gap-4 text-xs mb-3" style={{ color: "rgba(255,255,255,0.5)" }}>
+            <span>Correct: <span className="text-white font-semibold">{fmt(q.correct_pct, 1)}%</span></span>
+            <span>Avg Points: <span className="text-white font-semibold">{fmt(q.avg_points, 0)}</span></span>
+            <span>Answers: <span className="text-white font-semibold">{q.total_answers}</span></span>
+          </div>
+
+          {/* Option distribution bars */}
+          {q.options && q.options.length > 0 && (
+            <div className="space-y-1.5">
+              {q.options.map((opt: OptionDistribution, idx: number) => (
+                <div key={idx} className="flex items-center gap-2">
+                  <span className="text-xs w-28 truncate" style={{ color: "rgba(255,255,255,0.6)" }} title={opt.text}>
+                    {opt.text}
+                  </span>
+                  <div className="flex-1 h-4 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.06)" }}>
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${Math.max(opt.pct, 1)}%`,
+                        background: "linear-gradient(90deg, #f5c842, #ffd700)",
+                        opacity: 0.8,
+                      }}
+                    />
+                  </div>
+                  <span className="text-xs w-12 text-right font-semibold" style={{ color: "rgba(255,255,255,0.6)" }}>
+                    {fmt(opt.pct, 1)}%
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
+
+export function AnalyticsDashboardPage() {
+  // Games over time controls
+  const [period, setPeriod] = useState("day");
+  const [dateRange, setDateRange] = useState("30d");
+
+  // Top players sort
+  const [playerSort, setPlayerSort] = useState("score");
+
+  // Quiz performance sort
+  const [quizSort, setQuizSort] = useState("plays");
+  const [quizOrder, setQuizOrder] = useState("desc");
+
+  // Drill-down
+  const [expandedQuizId, setExpandedQuizId] = useState<string | null>(null);
+
+  // -----------------------------------------------------------------------
+  // Queries
+  // -----------------------------------------------------------------------
+
+  const {
+    data: overview,
+    isLoading: overviewLoading,
+    isError: overviewError,
+  } = useQuery({
+    queryKey: ["analytics", "overview"],
+    queryFn: fetchOverview,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const {
+    data: timeseries,
+    isLoading: timeseriesLoading,
+    isError: timeseriesError,
+  } = useQuery({
+    queryKey: ["analytics", "games-over-time", period, dateRange],
+    queryFn: () => fetchGamesOverTime(period, dateRange),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const {
+    data: quizPerf,
+    isLoading: quizPerfLoading,
+    isError: quizPerfError,
+  } = useQuery({
+    queryKey: ["analytics", "quiz-performance", quizSort, quizOrder],
+    queryFn: () => fetchQuizPerformance(quizSort, quizOrder),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const {
+    data: topPlayers,
+    isLoading: playersLoading,
+    isError: playersError,
+  } = useQuery({
+    queryKey: ["analytics", "top-players", playerSort],
+    queryFn: () => fetchTopPlayers(playerSort, 20),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const {
+    data: engagement,
+    isLoading: engagementLoading,
+    isError: engagementError,
+  } = useQuery({
+    queryKey: ["analytics", "engagement"],
+    queryFn: fetchEngagement,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // -----------------------------------------------------------------------
+  // Derived
+  // -----------------------------------------------------------------------
+
+  const isAllZeros =
+    overview &&
+    overview.total_quizzes === 0 &&
+    overview.total_games === 0 &&
+    overview.total_players === 0 &&
+    overview.total_answers === 0;
+
+  const heatmapGrid = engagement?.peak_hours ? buildHeatmapGrid(engagement.peak_hours) : null;
+  const heatmapMax = heatmapGrid
+    ? Math.max(...heatmapGrid.flat(), 1)
+    : 1;
+
+  // -----------------------------------------------------------------------
+  // Quiz sort toggle helper
+  // -----------------------------------------------------------------------
+
+  function handleQuizSort(field: string) {
+    if (quizSort === field) {
+      setQuizOrder((prev) => (prev === "desc" ? "asc" : "desc"));
+    } else {
+      setQuizSort(field);
+      setQuizOrder("desc");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  return (
+    <div>
+      {/* Title */}
+      <motion.h2
+        className="text-3xl font-black text-white mb-8"
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+      >
+        Analytics
+      </motion.h2>
+
+      {/* ============================================================== */}
+      {/* 1. Overview Cards                                              */}
+      {/* ============================================================== */}
+
+      {overviewLoading && <LoadingDots />}
+      {overviewError && <ErrorBox message="Failed to load analytics data." />}
+
+      {overview && isAllZeros && (
+        <motion.div
+          className="text-center py-16 rounded-2xl mb-8"
+          style={{ background: "rgba(245,200,66,0.05)", border: "2px dashed rgba(245,200,66,0.3)" }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          <p className="text-lg text-white mb-1">No analytics data yet.</p>
+          <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
+            Host some games to start seeing stats here.
+          </p>
+        </motion.div>
+      )}
+
+      {overview && !isAllZeros && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-8">
+            {OVERVIEW_CARDS.map((card, i) => {
+              const Icon = card.icon;
+              return (
+                <motion.div
+                  key={card.key}
+                  className="rounded-2xl p-4 sm:p-5"
+                  style={{
+                    background: "linear-gradient(135deg, rgba(42,20,66,0.7) 0%, rgba(30,15,50,0.8) 100%)",
+                    border: "1px solid rgba(245,200,66,0.12)",
+                  }}
+                  initial={{ opacity: 0, y: 15 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.06 }}
+                >
+                  <Icon className="w-5 h-5 mb-2" style={{ color: "#f5c842" }} />
+                  <p className="text-2xl sm:text-3xl font-black text-white leading-tight">
+                    {fmt(overview[card.key], card.decimal ?? 0)}
+                  </p>
+                  <p className="text-xs mt-1" style={{ color: "rgba(255,255,255,0.45)" }}>
+                    {card.label}
+                  </p>
+                </motion.div>
+              );
+            })}
+          </div>
+
+          {/* ============================================================== */}
+          {/* 2. Games Over Time                                             */}
+          {/* ============================================================== */}
+
+          <motion.div initial={{ opacity: 0, y: 15 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }}>
+            <SectionCard className="mb-8">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+                <h3 className="text-lg font-bold text-white">Games Over Time</h3>
+                <div className="flex flex-wrap gap-3">
+                  <ToggleGroup
+                    options={[
+                      { label: "Day", value: "day" },
+                      { label: "Week", value: "week" },
+                      { label: "Month", value: "month" },
+                    ]}
+                    value={period}
+                    onChange={setPeriod}
+                  />
+                  <ToggleGroup
+                    options={[
+                      { label: "7d", value: "7d" },
+                      { label: "30d", value: "30d" },
+                      { label: "90d", value: "90d" },
+                      { label: "All", value: "all" },
+                    ]}
+                    value={dateRange}
+                    onChange={setDateRange}
+                  />
+                </div>
+              </div>
+
+              {timeseriesLoading && <LoadingDots />}
+              {timeseriesError && <ErrorBox message="Failed to load chart data." />}
+
+              {timeseries && timeseries.length === 0 && (
+                <p className="text-center text-sm py-8" style={{ color: "rgba(255,255,255,0.4)" }}>
+                  No game data for this range.
+                </p>
+              )}
+
+              {timeseries && timeseries.length > 0 && (
+                <ResponsiveContainer width="100%" height={280}>
+                  <AreaChart data={timeseries} margin={{ top: 5, right: 5, left: -10, bottom: 5 }}>
+                    <defs>
+                      <linearGradient id="goldGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#f5c842" stopOpacity={0.4} />
+                        <stop offset="100%" stopColor="#f5c842" stopOpacity={0.02} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid stroke="rgba(255,255,255,0.06)" strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 12 }}
+                      stroke="rgba(255,255,255,0.1)"
+                      tickLine={false}
+                    />
+                    <YAxis
+                      tick={{ fill: "rgba(255,255,255,0.4)", fontSize: 12 }}
+                      stroke="rgba(255,255,255,0.1)"
+                      tickLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip content={<ChartTooltip />} />
+                    <Area
+                      type="monotone"
+                      dataKey="games"
+                      stroke="#f5c842"
+                      strokeWidth={2}
+                      fill="url(#goldGrad)"
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="players"
+                      stroke="rgba(255,255,255,0.35)"
+                      strokeWidth={1.5}
+                      fill="none"
+                      strokeDasharray="4 4"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              )}
+            </SectionCard>
+          </motion.div>
+
+          {/* ============================================================== */}
+          {/* 3. Top Players                                                 */}
+          {/* ============================================================== */}
+
+          <motion.div initial={{ opacity: 0, y: 15 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }}>
+            <SectionCard className="mb-8">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+                <h3 className="text-lg font-bold text-white">Top Players</h3>
+                <ToggleGroup
+                  options={[
+                    { label: "Score", value: "score" },
+                    { label: "Games", value: "games" },
+                  ]}
+                  value={playerSort}
+                  onChange={setPlayerSort}
+                />
+              </div>
+
+              {playersLoading && <LoadingDots />}
+              {playersError && <ErrorBox message="Failed to load player data." />}
+
+              {topPlayers && topPlayers.length === 0 && (
+                <p className="text-center text-sm py-8" style={{ color: "rgba(255,255,255,0.4)" }}>
+                  No player data yet.
+                </p>
+              )}
+
+              {topPlayers && topPlayers.length > 0 && (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr style={{ color: "rgba(255,255,255,0.4)" }}>
+                        <th className="text-left py-2 px-2 font-medium">#</th>
+                        <th className="text-left py-2 px-2 font-medium">Name</th>
+                        <th className="text-right py-2 px-2 font-medium">Total Score</th>
+                        <th className="text-right py-2 px-2 font-medium">Games</th>
+                        <th className="text-right py-2 px-2 font-medium">Avg Score</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {topPlayers.map((p, i) => (
+                        <tr
+                          key={`${p.name}-${i}`}
+                          className="transition-colors"
+                          style={{ borderTop: "1px solid rgba(255,255,255,0.05)" }}
+                        >
+                          <td className="py-2.5 px-2 font-bold" style={{ color: i < 3 ? "#f5c842" : "rgba(255,255,255,0.5)" }}>
+                            {i + 1}
+                          </td>
+                          <td className="py-2.5 px-2 text-white font-medium">{p.name}</td>
+                          <td className="py-2.5 px-2 text-right text-white">{fmt(p.total_score)}</td>
+                          <td className="py-2.5 px-2 text-right" style={{ color: "rgba(255,255,255,0.6)" }}>
+                            {p.games_played}
+                          </td>
+                          <td className="py-2.5 px-2 text-right" style={{ color: "rgba(255,255,255,0.6)" }}>
+                            {fmt(p.avg_score, 1)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </SectionCard>
+          </motion.div>
+
+          {/* ============================================================== */}
+          {/* 4. Quiz Performance                                            */}
+          {/* ============================================================== */}
+
+          <motion.div initial={{ opacity: 0, y: 15 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35 }}>
+            <SectionCard className="mb-8">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+                <h3 className="text-lg font-bold text-white">Quiz Performance</h3>
+              </div>
+
+              {quizPerfLoading && <LoadingDots />}
+              {quizPerfError && <ErrorBox message="Failed to load quiz data." />}
+
+              {quizPerf && quizPerf.length === 0 && (
+                <p className="text-center text-sm py-8" style={{ color: "rgba(255,255,255,0.4)" }}>
+                  No quiz data yet.
+                </p>
+              )}
+
+              {quizPerf && quizPerf.length > 0 && (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr style={{ color: "rgba(255,255,255,0.4)" }}>
+                        <th className="text-left py-2 px-2 font-medium">Quiz</th>
+                        <th
+                          className="text-right py-2 px-2 font-medium cursor-pointer select-none hover:text-white transition-colors"
+                          onClick={() => handleQuizSort("plays")}
+                        >
+                          Plays {quizSort === "plays" ? (quizOrder === "desc" ? "\u2193" : "\u2191") : ""}
+                        </th>
+                        <th
+                          className="text-right py-2 px-2 font-medium cursor-pointer select-none hover:text-white transition-colors"
+                          onClick={() => handleQuizSort("avg_score")}
+                        >
+                          Avg Score {quizSort === "avg_score" ? (quizOrder === "desc" ? "\u2193" : "\u2191") : ""}
+                        </th>
+                        <th className="text-right py-2 px-2 font-medium">Players</th>
+                        <th className="text-right py-2 px-2 font-medium">Questions</th>
+                        <th className="w-8" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {quizPerf.map((q: QuizStats) => {
+                        const isExpanded = expandedQuizId === q.id;
+                        return (
+                          <tr key={q.id} className="group" style={{ borderTop: "1px solid rgba(255,255,255,0.05)" }}>
+                            <td colSpan={6} className="p-0">
+                              <div
+                                className="flex items-center cursor-pointer px-2 py-2.5 transition-colors rounded-lg"
+                                style={{ background: isExpanded ? "rgba(245,200,66,0.05)" : "transparent" }}
+                                onClick={() => setExpandedQuizId(isExpanded ? null : q.id)}
+                              >
+                                <span className="flex-1 text-white font-medium truncate pr-2">{q.title}</span>
+                                <span className="w-16 text-right text-white">{q.plays}</span>
+                                <span className="w-20 text-right" style={{ color: "rgba(255,255,255,0.6)" }}>
+                                  {fmt(q.avg_score, 1)}
+                                </span>
+                                <span className="w-16 text-right" style={{ color: "rgba(255,255,255,0.6)" }}>
+                                  {q.player_count}
+                                </span>
+                                <span className="w-20 text-right" style={{ color: "rgba(255,255,255,0.6)" }}>
+                                  {q.question_count}
+                                </span>
+                                <span className="w-8 flex justify-center" style={{ color: "rgba(255,255,255,0.4)" }}>
+                                  {isExpanded ? (
+                                    <ChevronDown className="w-4 h-4" />
+                                  ) : (
+                                    <ChevronRight className="w-4 h-4" />
+                                  )}
+                                </span>
+                              </div>
+                              {isExpanded && (
+                                <div className="px-2 pb-3">
+                                  <QuestionDrillDown quizId={q.id} />
+                                </div>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </SectionCard>
+          </motion.div>
+
+          {/* ============================================================== */}
+          {/* 5. Engagement                                                  */}
+          {/* ============================================================== */}
+
+          <motion.div initial={{ opacity: 0, y: 15 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.4 }}>
+            <SectionCard className="mb-8">
+              <h3 className="text-lg font-bold text-white mb-5">Engagement</h3>
+
+              {engagementLoading && <LoadingDots />}
+              {engagementError && <ErrorBox message="Failed to load engagement data." />}
+
+              {engagement && (
+                <div className="space-y-6">
+                  {/* Avg Game Duration card */}
+                  <div
+                    className="inline-flex items-center gap-3 rounded-xl px-4 py-3"
+                    style={{
+                      background: "rgba(245,200,66,0.08)",
+                      border: "1px solid rgba(245,200,66,0.15)",
+                    }}
+                  >
+                    <Clock className="w-5 h-5" style={{ color: "#f5c842" }} />
+                    <div>
+                      <p className="text-xs" style={{ color: "rgba(255,255,255,0.45)" }}>Avg Game Duration</p>
+                      <p className="text-xl font-black text-white">
+                        {formatDuration(engagement.avg_game_duration_seconds)}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Peak Hours Heatmap */}
+                  {heatmapGrid && (
+                    <div>
+                      <p className="text-sm font-semibold text-white mb-3">Peak Hours</p>
+                      <div className="overflow-x-auto">
+                        <div className="inline-block">
+                          {/* Hour labels row */}
+                          <div className="flex items-center mb-1">
+                            <div className="w-10" />
+                            {Array.from({ length: 24 }, (_, h) => (
+                              <div
+                                key={h}
+                                className="text-center"
+                                style={{
+                                  width: 24,
+                                  fontSize: 9,
+                                  color: "rgba(255,255,255,0.3)",
+                                }}
+                              >
+                                {h}
+                              </div>
+                            ))}
+                          </div>
+
+                          {/* Rows */}
+                          {heatmapGrid.map((row, dayIdx) => (
+                            <div key={dayIdx} className="flex items-center mb-0.5">
+                              <div
+                                className="w-10 text-xs font-medium pr-2 text-right"
+                                style={{ color: "rgba(255,255,255,0.5)" }}
+                              >
+                                {DAY_LABELS[dayIdx]}
+                              </div>
+                              {row.map((count, hourIdx) => (
+                                <div
+                                  key={hourIdx}
+                                  className="rounded-sm"
+                                  style={{
+                                    width: 22,
+                                    height: 22,
+                                    margin: 1,
+                                    background: heatColor(count, heatmapMax),
+                                    transition: "background 0.2s",
+                                  }}
+                                  title={`${DAY_LABELS[dayIdx]} ${hourIdx}:00 — ${count} game${count !== 1 ? "s" : ""}`}
+                                />
+                              ))}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </SectionCard>
+          </motion.div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -145,3 +145,65 @@ export interface PlayerResults {
   rank: number;
   questions: PlayerResultQuestion[];
 }
+
+// Analytics types
+export interface OverviewStats {
+  total_quizzes: number;
+  total_games: number;
+  total_players: number;
+  total_answers: number;
+  avg_players_per_game: number;
+  avg_score: number;
+}
+
+export interface TimeSeriesPoint {
+  date: string;
+  games: number;
+  players: number;
+}
+
+export interface QuizStats {
+  id: string;
+  title: string;
+  plays: number;
+  avg_score: number;
+  player_count: number;
+  question_count: number;
+  created_at: string;
+}
+
+export interface OptionDistribution {
+  text: string;
+  count: number;
+  pct: number;
+}
+
+export interface QuestionStats {
+  id: string;
+  text: string;
+  type: string;
+  order: number;
+  correct_pct: number;
+  avg_points: number;
+  total_answers: number;
+  options: OptionDistribution[];
+}
+
+export interface PlayerStats {
+  name: string;
+  total_score: number;
+  games_played: number;
+  avg_score: number;
+  avg_speed_ms: number;
+}
+
+export interface PeakHourBucket {
+  day_of_week: number;
+  hour: number;
+  count: number;
+}
+
+export interface EngagementData {
+  peak_hours: PeakHourBucket[];
+  avg_game_duration_seconds: number;
+}


### PR DESCRIPTION
## Summary

- Add 6 backend analytics endpoints under `/api/v1/analytics/*` (overview, games-over-time, quizzes, quiz-questions drill-down, top players, engagement)
- Add frontend analytics dashboard page with Recharts at `/admin/analytics`
- Overview stat cards, games-over-time area chart, sortable quiz performance table with per-question drill-down, top players table, peak hours heatmap
- All data scoped to authenticated admin's quizzes via JWT auth

Closes #100

## Changes

### Backend
- `analytics.go`: 6 handler methods with SQL aggregation queries
- `analytics_test.go`: Tests for all endpoints (param validation, error handling)
- `handlers.go`: Register 6 analytics routes in auth group

### Frontend
- Install `recharts` dependency
- `api/analytics.ts`: 6 API fetch functions
- `types/index.ts`: Analytics TypeScript interfaces
- `AnalyticsDashboardPage.tsx`: Full dashboard with charts, tables, heatmap
- `AdminDashboardPage.tsx`: Add "Analytics" nav link
- `App.tsx`: Add `/admin/analytics` route

## Test plan

- [ ] All CI checks pass (backend build/test/lint, frontend typecheck/lint/test/build)
- [ ] Log in as admin → navigate to Analytics tab
- [ ] Verify overview cards show correct stats
- [ ] Toggle games-over-time chart period/range
- [ ] Sort quiz performance table, click to expand question drill-down
- [ ] Verify top players table sorts correctly
- [ ] Verify peak hours heatmap renders