### PR TITLE
fix: WebSocket auto-reconnection with exponential backoff

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -10,6 +10,9 @@ interface UseWebSocketOptions {
   enabled?: boolean;
 }
 
+const MAX_BACKOFF_MS = 16_000;
+const INITIAL_BACKOFF_MS = 1_000;
+
 export function useWebSocket({
   url,
   onMessage,
@@ -19,9 +22,11 @@ export function useWebSocket({
   enabled = true,
 }: UseWebSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null);
+  const intentionalClose = useRef(false);
+  const backoffMs = useRef(INITIAL_BACKOFF_MS);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Keep all callbacks in refs so they never appear in the effect deps.
-  // The effect only re-runs when url or enabled changes.
   const onMessageRef = useRef(onMessage);
   const onOpenRef = useRef(onOpen);
   const onCloseRef = useRef(onClose);
@@ -43,33 +48,62 @@ export function useWebSocket({
   useEffect(() => {
     if (!enabled) return;
 
-    const ws = new WebSocket(url);
-    wsRef.current = ws;
+    intentionalClose.current = false;
+    backoffMs.current = INITIAL_BACKOFF_MS;
 
-    ws.onopen = () => onOpenRef.current?.();
-    ws.onclose = () => onCloseRef.current?.();
-    ws.onerror = (e) => onErrorRef.current?.(e);
-    ws.onmessage = (event) => {
-      // writePump may batch multiple messages in one frame (newline-separated).
-      const frames = (event.data as string).split("\n").filter(Boolean);
-      for (const frame of frames) {
-        try {
-          const msg = JSON.parse(frame) as WsMessage;
-          onMessageRef.current(msg);
-        } catch {
-          console.error("Failed to parse WS message", frame);
+    function connect() {
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        backoffMs.current = INITIAL_BACKOFF_MS;
+        onOpenRef.current?.();
+      };
+
+      ws.onclose = () => {
+        onCloseRef.current?.();
+        if (!intentionalClose.current) {
+          // Schedule reconnect with exponential backoff
+          const delay = backoffMs.current;
+          backoffMs.current = Math.min(backoffMs.current * 2, MAX_BACKOFF_MS);
+          reconnectTimer.current = setTimeout(connect, delay);
         }
-      }
-    };
+      };
+
+      ws.onerror = (e) => onErrorRef.current?.(e);
+
+      ws.onmessage = (event) => {
+        // writePump may batch multiple messages in one frame (newline-separated).
+        const frames = (event.data as string).split("\n").filter(Boolean);
+        for (const frame of frames) {
+          try {
+            const msg = JSON.parse(frame) as WsMessage;
+            onMessageRef.current(msg);
+          } catch {
+            console.error("Failed to parse WS message", frame);
+          }
+        }
+      };
+    }
+
+    connect();
 
     // Close proactively on tab close / navigation so the server detects the
     // disconnect immediately rather than waiting for the ping/pong timeout.
-    const handlePageHide = () => ws.close();
+    const handlePageHide = () => {
+      intentionalClose.current = true;
+      wsRef.current?.close();
+    };
     window.addEventListener("pagehide", handlePageHide);
 
     return () => {
+      intentionalClose.current = true;
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current);
+        reconnectTimer.current = null;
+      }
       window.removeEventListener("pagehide", handlePageHide);
-      ws.close();
+      wsRef.current?.close();
     };
   }, [url, enabled]); // callbacks intentionally excluded — they live in refs
 

--- a/frontend/src/test/useWebSocket.test.ts
+++ b/frontend/src/test/useWebSocket.test.ts
@@ -1,10 +1,10 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useWebSocket } from "../hooks/useWebSocket";
 import type { WsMessage } from "../types";
 
-// Capture the WebSocket instance created by the hook so we can assert on it.
-let lastWsInstance: MockWebSocket | null = null;
+// Track all created instances for assertions.
+const wsInstances: MockWebSocket[] = [];
 
 class MockWebSocket {
   close = vi.fn();
@@ -16,8 +16,7 @@ class MockWebSocket {
   onmessage: ((e: MessageEvent) => void) | null = null;
 
   constructor() {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    lastWsInstance = this;
+    wsInstances.push(this);
   }
 }
 
@@ -25,11 +24,13 @@ const noop = (_: WsMessage) => {};
 
 describe("useWebSocket", () => {
   beforeEach(() => {
-    lastWsInstance = null;
+    wsInstances.length = 0;
     vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -44,7 +45,7 @@ describe("useWebSocket", () => {
     expect(pagehideCall).toBeDefined();
 
     window.dispatchEvent(new Event("pagehide"));
-    expect(lastWsInstance!.close).toHaveBeenCalled();
+    expect(wsInstances[0]!.close).toHaveBeenCalled();
 
     addSpy.mockRestore();
   });
@@ -72,7 +73,7 @@ describe("useWebSocket", () => {
     );
 
     unmount();
-    expect(lastWsInstance!.close).toHaveBeenCalled();
+    expect(wsInstances[0]!.close).toHaveBeenCalled();
   });
 
   it("does not open a socket when enabled=false", () => {
@@ -84,6 +85,77 @@ describe("useWebSocket", () => {
       }),
     );
 
-    expect(lastWsInstance).toBeNull();
+    expect(wsInstances).toHaveLength(0);
+  });
+
+  it("reconnects with exponential backoff on unexpected close", () => {
+    const onClose = vi.fn();
+    renderHook(() =>
+      useWebSocket({
+        url: "ws://test/socket",
+        onMessage: noop,
+        onClose,
+        enabled: true,
+      }),
+    );
+
+    expect(wsInstances).toHaveLength(1);
+
+    // Simulate unexpected close
+    act(() => wsInstances[0].onclose?.());
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // After 1s backoff, should reconnect
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(wsInstances).toHaveLength(2);
+
+    // Second unexpected close — 2s backoff
+    act(() => wsInstances[1].onclose?.());
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(wsInstances).toHaveLength(2); // not yet
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(wsInstances).toHaveLength(3);
+  });
+
+  it("resets backoff after successful open", () => {
+    renderHook(() =>
+      useWebSocket({ url: "ws://test/socket", onMessage: noop, enabled: true }),
+    );
+
+    // Close and reconnect
+    act(() => wsInstances[0].onclose?.());
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(wsInstances).toHaveLength(2);
+
+    // Successful open resets backoff
+    act(() => wsInstances[1].onopen?.());
+
+    // Close again — should be back to 1s backoff, not 2s
+    act(() => wsInstances[1].onclose?.());
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(wsInstances).toHaveLength(3);
+  });
+
+  it("does not reconnect after intentional unmount", () => {
+    const { unmount } = renderHook(() =>
+      useWebSocket({ url: "ws://test/socket", onMessage: noop, enabled: true }),
+    );
+
+    unmount();
+    act(() => { vi.advanceTimersByTime(20000); });
+    expect(wsInstances).toHaveLength(1); // no reconnection attempts
+  });
+
+  it("does not reconnect after pagehide", () => {
+    renderHook(() =>
+      useWebSocket({ url: "ws://test/socket", onMessage: noop, enabled: true }),
+    );
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    // Simulate close triggered by pagehide
+    act(() => wsInstances[0].onclose?.());
+    act(() => { vi.advanceTimersByTime(20000); });
+    expect(wsInstances).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
Previously, a dropped WebSocket connection was permanent — players/hosts would lose connection with no recovery. This was the most likely cause of reported "game failed" issues on mobile/flaky networks.

Now `useWebSocket` auto-reconnects with exponential backoff:
- 1s → 2s → 4s → 8s → 16s (max)
- Resets to 1s on successful reconnection
- Skips reconnection on intentional close (unmount, page navigation)

## Test plan
- [ ] 8 unit tests covering: reconnection, backoff, backoff reset, no reconnect on unmount, no reconnect on pagehide
- [ ] Manual: open game on mobile, toggle airplane mode briefly, verify reconnection