### PR TITLE
Release v1.3.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ PORT=8081
 # Fly.io prod: https://hilal-frontend.fly.dev
 FRONTEND_URL=http://localhost:5173
 
+# Additional allowed origins for CORS and WebSocket (comma-separated).
+# FRONTEND_URL is always included automatically.
+# Fly.io prod example: https://www.playhilal.com,https://hilal-frontend.fly.dev
+ALLOWED_ORIGINS=
+
 # Anthropic API key for AI quiz generation
 # Get one at https://console.anthropic.com
 ANTHROPIC_API_KEY=

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -66,7 +66,7 @@ func main() {
 	r.Use(chimw.RequestID)
 	r.Use(mw.RequestID) // correlation ID propagation
 	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{cfg.FrontendURL},
+		AllowedOrigins:   cfg.AllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
 		AllowCredentials: true,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	RedisURL           string
 	JWTSecret          string
 	FrontendURL        string
+	AllowedOrigins     []string
 	AnthropicAPIKey    string
 	AIRateLimitPerHour int
 	MaxAIQuestions     int
@@ -42,12 +43,29 @@ func Load() *Config {
 		}
 	}
 
+	frontendURL := getEnv("FRONTEND_URL", "http://localhost:5173")
+
+	// Build allowed origins list: ALLOWED_ORIGINS (comma-separated) + FRONTEND_URL.
+	var allowedOrigins []string
+	if extra := os.Getenv("ALLOWED_ORIGINS"); extra != "" {
+		for _, o := range strings.Split(extra, ",") {
+			if trimmed := strings.TrimSpace(o); trimmed != "" {
+				allowedOrigins = append(allowedOrigins, trimmed)
+			}
+		}
+	}
+	// Always include the primary frontend URL.
+	if frontendURL != "" && !sliceContains(allowedOrigins, frontendURL) {
+		allowedOrigins = append(allowedOrigins, frontendURL)
+	}
+
 	return &Config{
 		Port:               getEnv("PORT", "8081"),
 		DatabaseURL:        getEnv("DATABASE_URL", "postgres://hilal:hilal@localhost:5432/hilal?sslmode=disable"),
 		RedisURL:           getEnv("REDIS_URL", "redis://localhost:6379"),
 		JWTSecret:          getEnv("JWT_SECRET", ""),
-		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:5173"),
+		FrontendURL:        frontendURL,
+		AllowedOrigins:     allowedOrigins,
 		AnthropicAPIKey:    anthropicKey,
 		AIRateLimitPerHour: aiRateLimit,
 		MaxAIQuestions:     maxAIQuestions,
@@ -90,6 +108,15 @@ func (c *Config) Validate() error {
 func containsControlChars(s string) bool {
 	for _, r := range s {
 		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContains(ss []string, target string) bool {
+	for _, s := range ss {
+		if s == target {
 			return true
 		}
 	}

--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -17,12 +17,18 @@ import (
 	"github.com/HassanA01/Hilal/backend/internal/models"
 )
 
-func newUpgrader(frontendURL string) *websocket.Upgrader {
+func newUpgrader(allowedOrigins []string) *websocket.Upgrader {
 	return &websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
 		CheckOrigin: func(r *http.Request) bool {
-			return r.Header.Get("Origin") == frontendURL
+			origin := r.Header.Get("Origin")
+			for _, o := range allowedOrigins {
+				if origin == o {
+					return true
+				}
+			}
+			return false
 		},
 	}
 }
@@ -37,7 +43,7 @@ const (
 func (h *Handler) HostWebSocket(w http.ResponseWriter, r *http.Request) {
 	sessionCode := chi.URLParam(r, "sessionCode")
 
-	conn, err := newUpgrader(h.config.FrontendURL).Upgrade(w, r, nil)
+	conn, err := newUpgrader(h.config.AllowedOrigins).Upgrade(w, r, nil)
 	if err != nil {
 		slog.Error("ws upgrade error", "error", err)
 		return
@@ -69,7 +75,7 @@ func (h *Handler) PlayerWebSocket(w http.ResponseWriter, r *http.Request) {
 	playerID := r.URL.Query().Get("player_id")
 	playerName := r.URL.Query().Get("name")
 
-	conn, err := newUpgrader(h.config.FrontendURL).Upgrade(w, r, nil)
+	conn, err := newUpgrader(h.config.AllowedOrigins).Upgrade(w, r, nil)
 	if err != nil {
 		slog.Error("ws upgrade error", "error", err)
 		return


### PR DESCRIPTION
## Summary

- **fix: WebSocket origin check** — `CheckOrigin` rejected Fly.io internal origins (`http://hilal-frontend.fly.dev`), preventing hosts from connecting via WebSocket in production. Added `ALLOWED_ORIGINS` env var to support multiple origins for both CORS and WebSocket.

## Release v1.3.1