### PR TITLE
debug: log rejected WebSocket origin

### DIFF
--- a/backend/internal/handlers/websocket.go
+++ b/backend/internal/handlers/websocket.go
@@ -28,6 +28,7 @@ func newUpgrader(allowedOrigins []string) *websocket.Upgrader {
 					return true
 				}
 			}
+			slog.Warn("ws origin rejected", "origin", origin, "allowed", allowedOrigins)
 			return false
 		},
 	}


### PR DESCRIPTION
Temporary diagnostic logging to identify the Origin mismatch causing 403 on WebSocket upgrade.