### PR TITLE
feat: ordering reveal animation, podium messages, copy questions

### DIFF
--- a/frontend/src/components/PodiumScreen.tsx
+++ b/frontend/src/components/PodiumScreen.tsx
@@ -166,11 +166,20 @@ function PodiumBlock({
   );
 }
 
+const PODIUM_MESSAGES = [
+  "\u0631\u064E\u0628\u0650\u0651 \u0632\u0650\u062F\u0652\u0646\u0650\u064A \u0639\u0650\u0644\u0652\u0645\u064B\u0627 \u2014 My Lord, increase me in knowledge",
+  "Knowledge shared is knowledge multiplied",
+  "Thanks for playing! Keep learning, keep growing",
+  "Every question answered is a step forward",
+  "Well played! May your curiosity never fade",
+];
+
 export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Dashboard", playerResults }: Props) {
   const top3 = entries.slice(0, 3);
   const rest = entries.slice(3);
   const myEntry = entries.find((e) => e.player_id === playerId);
   const firedRef = useRef(false);
+  const [podiumMessage] = useState(() => PODIUM_MESSAGES[Math.floor(Math.random() * PODIUM_MESSAGES.length)]);
 
   useEffect(() => {
     if (!firedRef.current) {
@@ -207,7 +216,7 @@ export function PodiumScreen({ entries, playerId, onEnd, endLabel = "Back to Das
           <h1 className="text-4xl font-black mb-2" style={{ color: "#f5c842", textShadow: "0 0 20px rgba(245,200,66,0.6)" }}>
             Game Over!
           </h1>
-          <p style={{ color: "rgba(255,255,255,0.7)" }}>May your Iftaar be blessed ✨</p>
+          <p style={{ color: "rgba(255,255,255,0.7)" }}>{podiumMessage}</p>
         </motion.div>
 
         {/* Podium — order: 2nd, 1st, 3rd */}

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { motion } from "motion/react";
+import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 import { ChevronRight, Users, LogOut, Volume2, VolumeOff } from "lucide-react";
 import { CrescentIcon } from "../components/icons";
 import { useWebSocket } from "../hooks/useWebSocket";
@@ -48,6 +48,88 @@ const TYPE_LABELS: Record<string, string> = {
   image_choice: "Image Choice",
   ordering: "Ordering",
 };
+
+/** Deterministic shuffle using a simple hash of the questionId as seed. */
+function seededShuffle<T>(arr: T[], seed: string): T[] {
+  const copy = [...arr];
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = ((h << 5) - h + seed.charCodeAt(i)) | 0;
+  for (let i = copy.length - 1; i > 0; i--) {
+    h = (h * 1664525 + 1013904223) | 0;
+    const j = ((h >>> 0) % (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function useDelayedFlag(active: boolean, delayMs: number, resetKey: string): boolean {
+  const [flag, setFlag] = useState(false);
+  useEffect(() => {
+    if (!active) { setFlag(false); return; }
+    const timer = setTimeout(() => setFlag(true), delayMs);
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, delayMs, resetKey]);
+  return flag;
+}
+
+function OrderingReveal({ options, questionId, revealed, correctOrder }: {
+  options: HostOption[];
+  questionId: string;
+  revealed: boolean;
+  correctOrder?: string[];
+}) {
+  const shuffled = useMemo(() => seededShuffle(options, questionId), [options, questionId]);
+  const settled = useDelayedFlag(revealed, 700, questionId);
+
+  // During question: shuffled order. On reveal: correct order.
+  const displayOptions = revealed && correctOrder
+    ? correctOrder.map((id) => options.find((o) => o.id === id)!).filter(Boolean)
+    : shuffled;
+
+  return (
+    <LayoutGroup>
+      {displayOptions.map((opt, i) => (
+        <motion.div
+          key={opt.id}
+          layout
+          className="flex items-center gap-3 px-4 py-3 rounded-xl"
+          style={{
+            background: settled ? "rgba(76,175,80,0.15)" : "rgba(255,255,255,0.08)",
+            border: `1px solid ${settled ? "rgba(76,175,80,0.3)" : "rgba(245,200,66,0.2)"}`,
+            transition: "background 0.4s ease, border-color 0.4s ease",
+          }}
+          transition={{ type: "spring", stiffness: 300, damping: 30 }}
+        >
+          <div
+            className="w-9 h-9 rounded-lg flex items-center justify-center font-bold shrink-0 text-sm"
+            style={{
+              background: settled ? "#4caf50" : "rgba(245,200,66,0.3)",
+              color: settled ? "white" : "#f5c842",
+              transition: "background 0.4s ease, color 0.4s ease",
+            }}
+          >
+            {revealed ? i + 1 : "•"}
+          </div>
+          <span className="font-medium text-white flex-1 text-sm leading-snug">{opt.text}</span>
+          <AnimatePresence>
+            {settled && (
+              <motion.span
+                className="text-xl font-black shrink-0"
+                style={{ color: "#4caf50" }}
+                initial={{ scale: 0, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ type: "spring", stiffness: 300, delay: i * 0.08 }}
+              >
+                &#x2713;
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </motion.div>
+      ))}
+    </LayoutGroup>
+  );
+}
 
 export function HostGamePage() {
   const { code } = useParams<{ code: string }>();
@@ -355,7 +437,7 @@ export function HostGamePage() {
             initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.15 }}>
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-base font-bold" style={{ color: "rgba(255,255,255,0.8)" }}>
-                {isOrdering ? "Correct Order" : "Answer Options"}
+                {isOrdering && phase === "reveal" ? "Correct Order" : "Answer Options"}
               </h3>
               {phase === "reveal" && (
                 <span className="text-xs px-2 py-0.5 rounded-full font-medium" style={{ background: "rgba(76,175,80,0.2)", color: "#4caf50" }}>Revealed</span>
@@ -363,31 +445,12 @@ export function HostGamePage() {
             </div>
 
             {isOrdering ? (
-              /* ── Ordering options (shown in correct order for host) ── */
-              currentQuestion.question.options.map((opt, i) => {
-                const revealed = phase === "reveal";
-                return (
-                  <motion.div key={opt.id}
-                    className="flex items-center gap-3 px-4 py-3 rounded-xl"
-                    style={{
-                      background: revealed ? "rgba(76,175,80,0.15)" : "rgba(255,255,255,0.08)",
-                      border: `1px solid ${revealed ? "rgba(76,175,80,0.3)" : "rgba(245,200,66,0.2)"}`,
-                    }}
-                    initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: i * 0.08 }}>
-                    <div className="w-9 h-9 rounded-lg flex items-center justify-center font-bold text-white shrink-0 text-sm"
-                      style={{ background: revealed ? "#4caf50" : "rgba(245,200,66,0.3)", color: revealed ? "white" : "#f5c842" }}>
-                      {i + 1}
-                    </div>
-                    <span className="font-medium text-white flex-1 text-sm leading-snug">{opt.text}</span>
-                    {revealed && (
-                      <motion.span className="text-xl font-black shrink-0" style={{ color: "#4caf50" }}
-                        initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ type: "spring", stiffness: 300 }}>
-                        &#x2713;
-                      </motion.span>
-                    )}
-                  </motion.div>
-                );
-              })
+              <OrderingReveal
+                options={currentQuestion.question.options}
+                questionId={currentQuestion.question.id}
+                revealed={phase === "reveal"}
+                correctOrder={revealPayload?.correct_order}
+              />
             ) : (
               /* ── MC / TF / Image Choice options ── */
               currentQuestion.question.options.map((opt, i) => {

--- a/frontend/src/pages/HostGamePage.tsx
+++ b/frontend/src/pages/HostGamePage.tsx
@@ -65,10 +65,8 @@ function seededShuffle<T>(arr: T[], seed: string): T[] {
 function useDelayedFlag(active: boolean, delayMs: number, resetKey: string): boolean {
   const [flag, setFlag] = useState(false);
   useEffect(() => {
-    if (!active) { setFlag(false); return; }
-    const timer = setTimeout(() => setFlag(true), delayMs);
+    const timer = setTimeout(() => setFlag(active), active ? delayMs : 0);
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, delayMs, resetKey]);
   return flag;
 }

--- a/frontend/src/pages/QuizFormPage.tsx
+++ b/frontend/src/pages/QuizFormPage.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { motion, AnimatePresence, Reorder } from "motion/react";
-import { Plus, Trash2, Check, Sparkles, ArrowUp, ArrowDown, Image, Loader2, X, GripVertical } from "lucide-react";
+import { Plus, Trash2, Check, Sparkles, ArrowUp, ArrowDown, Image, Loader2, X, GripVertical, Copy } from "lucide-react";
 import { CrescentIcon } from "../components/icons";
 import { getQuiz, createQuiz, updateQuiz } from "../api/quizzes";
 import type { Quiz, QuestionType } from "../types";
@@ -101,6 +101,36 @@ function QuizForm({ quizID, initial }: QuizFormProps) {
   const [uploadingQuestion, setUploadingQuestion] = useState<number | null>(null);
   const [uploadingOption, setUploadingOption] = useState<{ q: number; o: number } | null>(null);
   const [invalidImageUrls, setInvalidImageUrls] = useState<Set<string>>(new Set());
+  const [copied, setCopied] = useState(false);
+
+  function copyQuestions() {
+    const TYPE_LABELS: Record<string, string> = {
+      multiple_choice: "Multiple Choice",
+      multi_select: "Multi Select",
+      true_false: "True/False",
+      ordering: "Ordering",
+      image_choice: "Image Choice",
+    };
+    const lines: string[] = [];
+    if (title.trim()) lines.push(`Quiz: ${title.trim()}`, "");
+    questions.forEach((q, i) => {
+      const label = TYPE_LABELS[q.type] ?? q.type;
+      lines.push(`${i + 1}. ${q.text || "(no text)"} (${label}, ${q.time_limit}s)`);
+      q.options.forEach((o, j) => {
+        if (q.type === "ordering") {
+          lines.push(`   ${j + 1}. ${o.text || "(no text)"}`);
+        } else {
+          const marker = o.is_correct ? " \u2713" : "";
+          lines.push(`   ${String.fromCharCode(65 + j)}) ${o.text || "(no text)"}${marker}`);
+        }
+      });
+      lines.push("");
+    });
+    navigator.clipboard.writeText(lines.join("\n")).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
 
   const mutation = useMutation({
     mutationFn: (input: { title: string; questions: QuestionInput[] }) =>
@@ -618,6 +648,13 @@ function QuizForm({ quizID, initial }: QuizFormProps) {
             whileHover={!mutation.isPending ? { scale: 1.02 } : {}}
             whileTap={!mutation.isPending ? { scale: 0.98 } : {}}>
             {mutation.isPending ? "Saving…" : isEdit ? "Save changes" : "Create quiz"}
+          </motion.button>
+          <motion.button type="button" onClick={copyQuestions}
+            className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-medium transition"
+            style={{ background: "rgba(245,200,66,0.1)", color: copied ? "#4caf50" : "#f5c842", border: "1px solid rgba(245,200,66,0.25)" }}
+            whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+            {copied ? "Copied!" : "Copy"}
           </motion.button>
           <button type="button" onClick={() => navigate("/admin/quizzes")}
             className="text-sm transition" style={{ color: "rgba(255,255,255,0.4)" }}>

--- a/frontend/src/test/HostGamePage.test.tsx
+++ b/frontend/src/test/HostGamePage.test.tsx
@@ -218,7 +218,7 @@ describe("HostGamePage", () => {
       }),
     );
     expect(screen.getByText("Arrange these events in order")).toBeInTheDocument();
-    expect(screen.getByText("Correct Order")).toBeInTheDocument();
+    expect(screen.getByText("Answer Options")).toBeInTheDocument();
     expect(screen.getByText("Event A")).toBeInTheDocument();
     expect(screen.getByText("Ordering")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- **#141** — Hide correct order from host during ordering questions. On reveal, options smoothly animate into correct positions via `LayoutGroup`, then turn green with staggered checkmarks
- **#142** — Replace "May your Iftaar be blessed" with rotating messages (dua for knowledge, thank-you messages, etc.)
- **#143** — Add "Copy" button on quiz form that copies all questions to clipboard in human-readable format

Closes #141, Closes #142, Closes #143

## How to test
1. **Ordering**: Create quiz with ordering question → host game → verify host sees shuffled options during question → on reveal, watch options glide into correct order then turn green
2. **Podium**: Finish a game → check podium message (refresh to see different ones)
3. **Copy**: Open quiz form → click Copy button → paste in editor → verify format